### PR TITLE
update provisioning datasource guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ apiVersion: 1
 
 datasources:
   - name: Quickwit
-    type: quickwit
-    database: 'hdfs-logs'
+    type: quickwit-quickwit-datasource
     url: http://localhost:7280/api/v1
     jsonData:
+      index: 'hdfs-logs'
       timeField: timestamp
       timeOutputFormat: unix_timestamp_secs
       logMessageField: body


### PR DESCRIPTION
1.  Change type name
https://github.com/quickwit-oss/quickwit-datasource/blob/main/src/plugin.json#L5
2. Use jsonData.index instead
https://grafana.com/docs/grafana/latest/datasources/elasticsearch/#provision-the-data-source