### PR TITLE
Use AND as default operator, fixes #54

### DIFF
--- a/pkg/quickwit/client/models.go
+++ b/pkg/quickwit/client/models.go
@@ -102,6 +102,7 @@ type QueryStringFilter struct {
 	Filter
 	Query           string
 	AnalyzeWildcard bool
+	DefaultOperator string
 }
 
 // MarshalJSON returns the JSON encoding of the query string filter.
@@ -109,7 +110,8 @@ func (f *QueryStringFilter) MarshalJSON() ([]byte, error) {
 	// FIXME: readd analyze_wildcard when quickwit supports it.
 	root := map[string]interface{}{
 		"query_string": map[string]interface{}{
-			"query": f.Query,
+			"query":            f.Query,
+			"default_operator": f.DefaultOperator,
 			//			"analyze_wildcard": f.AnalyzeWildcard,
 		},
 	}

--- a/pkg/quickwit/client/search_request.go
+++ b/pkg/quickwit/client/search_request.go
@@ -257,7 +257,7 @@ func (b *FilterQueryBuilder) AddDateRangeFilter(timeField string, lteMillisecs i
 }
 
 // AddQueryStringFilter adds a new query string filter
-func (b *FilterQueryBuilder) AddQueryStringFilter(querystring string, analyseWildcard bool) *FilterQueryBuilder {
+func (b *FilterQueryBuilder) AddQueryStringFilter(querystring string, analyseWildcard bool, defaultOperator string) *FilterQueryBuilder {
 	if len(strings.TrimSpace(querystring)) == 0 {
 		return b
 	}
@@ -265,6 +265,7 @@ func (b *FilterQueryBuilder) AddQueryStringFilter(querystring string, analyseWil
 	b.filters = append(b.filters, &QueryStringFilter{
 		Query:           querystring,
 		AnalyzeWildcard: analyseWildcard,
+		DefaultOperator: defaultOperator,
 	})
 	return b
 }

--- a/pkg/quickwit/client/search_request_test.go
+++ b/pkg/quickwit/client/search_request_test.go
@@ -48,7 +48,7 @@ func TestSearchRequest(t *testing.T) {
 		b.Sort(SortOrderDesc, timeField, "epoch_nanos_int")
 		filters := b.Query().Bool().Filter()
 		filters.AddDateRangeFilter(timeField, 1684398201000, 1684308201000)
-		filters.AddQueryStringFilter("test", true)
+		filters.AddQueryStringFilter("test", true, "AND")
 
 		t.Run("When building search request", func(t *testing.T) {
 			sr, err := b.Build()

--- a/pkg/quickwit/data_query.go
+++ b/pkg/quickwit/data_query.go
@@ -91,7 +91,7 @@ func (e *elasticsearchDataQuery) processQuery(q *Query, ms *es.MultiSearchReques
 	b.Size(0)
 	filters := b.Query().Bool().Filter()
 	filters.AddDateRangeFilter(defaultTimeField, to, from)
-	filters.AddQueryStringFilter(q.RawQuery, true)
+	filters.AddQueryStringFilter(q.RawQuery, true, "AND")
 
 	if isLogsQuery(q) {
 		processLogsQuery(q, b, from, to, defaultTimeField)


### PR DESCRIPTION
Add a `DefaultOperator` property to `QueryStringFilter` and use `"AND"` as default operator in processQuery (cf : https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html)