### PR TITLE
Debounce query editor changes, improve usability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@reduxjs/toolkit": "^1.9.5",
         "@uiw/react-codemirror": "^4.21.21",
         "lucene": "^2.1.1",
+        "observable-hooks": "^4.2.3",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "tslib": "2.5.3"
@@ -13498,6 +13499,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/observable-hooks": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/observable-hooks/-/observable-hooks-4.2.3.tgz",
+      "integrity": "sha512-d6fYTIU+9sg1V+CT0GhgoE/ntjIqcy9DGaYGE6ELGVP4ojaWIEsaLvL/05hLOM+AL7aySN4DCTLvj6dDF9T8XA==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "rxjs": ">=6.0.0"
       }
     },
     "node_modules/ol": {
@@ -27896,6 +27907,12 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
+    },
+    "observable-hooks": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/observable-hooks/-/observable-hooks-4.2.3.tgz",
+      "integrity": "sha512-d6fYTIU+9sg1V+CT0GhgoE/ntjIqcy9DGaYGE6ELGVP4ojaWIEsaLvL/05hLOM+AL7aySN4DCTLvj6dDF9T8XA==",
+      "requires": {}
     },
     "ol": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@reduxjs/toolkit": "^1.9.5",
     "@uiw/react-codemirror": "^4.21.21",
     "lucene": "^2.1.1",
+    "observable-hooks": "^4.2.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "tslib": "2.5.3"

--- a/src/LogContext/components/LogContextUI.tsx
+++ b/src/LogContext/components/LogContextUI.tsx
@@ -64,7 +64,7 @@ export function LogContextUI(props: LogContextUIProps ){
         <LogContextQueryBuilderSidebar {...props} builder={builder} updateQuery={setParsedQuery} searchableFields={fields}/>
         <div className={css`width:100%; display:flex; flex-direction:column; gap:0.5rem; min-width:0;`}>
           {ActionBar}
-          <LuceneQueryEditor builder={builder} autocompleter={getSuggestions} onChange={builder.setQuery}/>
+          <LuceneQueryEditor value={builder.query} autocompleter={getSuggestions} onChange={builder.setQuery}/>
         </div>
       </DatasourceContext.Provider>
     </div>

--- a/src/components/QueryEditor/index.tsx
+++ b/src/components/QueryEditor/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import React, { createContext, useCallback, useEffect } from 'react';
+import React, { createContext } from 'react';
 
 import { CoreApp, Field, getDefaultTimeRange, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { InlineLabel, useStyles2 } from '@grafana/ui';
@@ -18,7 +18,6 @@ import { changeQuery } from './state';
 import { QuickwitOptions } from '../../quickwit';
 import { QueryTypeSelector } from './QueryTypeSelector';
 
-import { useQueryBuilder } from '@/QueryBuilder/lucene';
 import { getHook } from 'utils/context';
 import { LuceneQueryEditor } from '@/components/LuceneQueryEditor';
 import { useDatasourceFields } from 'datasource.utils';
@@ -59,23 +58,12 @@ interface Props {
 
 export const ElasticSearchQueryField = ({ value, onChange }: { value?: string; onChange: (v: string) => void }) => {
   const styles = useStyles2(getStyles);
-  const builder = useQueryBuilder();
-  const {setQuery} = builder;
   const datasource = useDatasource()
   const { getSuggestions } = useDatasourceFields(datasource);
 
-  useEffect(()=>{
-    setQuery(value || '')
-  }, [setQuery, value])
-
-  const onEditorChange = useCallback((query: string)=>{
-    setQuery(query);
-    onChange(query)
-  },[setQuery, onChange])
-
   return (
     <div className={styles.queryItem}>
-        <LuceneQueryEditor placeholder="Enter a lucene query" builder={builder} autocompleter={getSuggestions} onChange={onEditorChange}/>
+      <LuceneQueryEditor placeholder="Enter a lucene query" value={value || ''} autocompleter={getSuggestions} onChange={onChange}/>
     </div>
   );
 };


### PR DESCRIPTION
This PR uses RxJS's debounceTime to avoid firing bursts of calls to onChange when editing the query. Prevents tripping unnecessary rerenders and greatly improves usability.

Introduces a dependency on [crimx/observable-hooks](https://github.com/crimx/observable-hooks)