### PR TITLE
Don't send index metadata, revamp Elastic querybuilder

### DIFF
--- a/src/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/src/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -17,7 +17,7 @@ import {
 } from './actions';
 
 export const createReducer =
-  (defaultTimeField = "default timefield") =>
+  (defaultTimeField = "") =>
   (state: ElasticsearchQuery['bucketAggs'], action: Action): ElasticsearchQuery['bucketAggs'] => {
     if (addBucketAggregation.match(action)) {
       const newAgg: Terms = {

--- a/src/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/src/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -17,7 +17,7 @@ import {
 } from './actions';
 
 export const createReducer =
-  (defaultTimeField: string) =>
+  (defaultTimeField = "default timefield") =>
   (state: ElasticsearchQuery['bucketAggs'], action: Action): ElasticsearchQuery['bucketAggs'] => {
     if (addBucketAggregation.match(action)) {
       const newAgg: Terms = {

--- a/src/components/QueryEditor/ElasticsearchQueryContext.test.tsx
+++ b/src/components/QueryEditor/ElasticsearchQueryContext.test.tsx
@@ -18,7 +18,7 @@ const query: ElasticsearchQuery = {
 
 describe('ElasticsearchQueryContext', () => {
   it('Should call onChange and onRunQuery with the default query when the query is empty', () => {
-    const datasource = { timeField: 'TIMEFIELD' } as ElasticDatasource;
+    const datasource = {} as ElasticDatasource;
     const onChange = jest.fn();
     const onRunQuery = jest.fn();
 
@@ -38,9 +38,6 @@ describe('ElasticsearchQueryContext', () => {
     expect(changedQuery.alias).toBeDefined();
     expect(changedQuery.metrics).toBeDefined();
     expect(changedQuery.bucketAggs).toBeDefined();
-
-    // Should also set timeField to the configured `timeField` option in datasource configuration
-    expect(changedQuery.timeField).toBe(datasource.timeField);
 
     expect(onRunQuery).toHaveBeenCalled();
   });

--- a/src/components/QueryEditor/ElasticsearchQueryContext.test.tsx
+++ b/src/components/QueryEditor/ElasticsearchQueryContext.test.tsx
@@ -18,7 +18,7 @@ const query: ElasticsearchQuery = {
 
 describe('ElasticsearchQueryContext', () => {
   it('Should call onChange and onRunQuery with the default query when the query is empty', () => {
-    const datasource = {} as ElasticDatasource;
+    const datasource = { timeField: 'TIMEFIELD' } as ElasticDatasource;
     const onChange = jest.fn();
     const onRunQuery = jest.fn();
 
@@ -38,6 +38,8 @@ describe('ElasticsearchQueryContext', () => {
     expect(changedQuery.alias).toBeDefined();
     expect(changedQuery.metrics).toBeDefined();
     expect(changedQuery.bucketAggs).toBeDefined();
+    // Should also set timeField to the configured `timeField` option in datasource configuration
+    expect(changedQuery.timeField).toBe(datasource.timeField);
 
     expect(onRunQuery).toHaveBeenCalled();
   });

--- a/src/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/src/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -50,11 +50,12 @@ export const ElasticsearchProvider = ({
     query: queryReducer,
     alias: aliasPatternReducer,
     metrics: metricsReducer,
-    bucketAggs: createBucketAggsReducer(),
+    bucketAggs: createBucketAggsReducer(datasource.timeField),
   });
 
   const dispatch = useStatelessReducer(
-    (newState) => onStateChange({ ...query, ...newState }),
+      // timeField is part of the query model, but its value is always set to be the one from datasource settings.
+      (newState) => onStateChange({ ...query, ...newState, timeField: datasource.timeField }),
     query,
     reducer
   );

--- a/src/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/src/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -50,12 +50,11 @@ export const ElasticsearchProvider = ({
     query: queryReducer,
     alias: aliasPatternReducer,
     metrics: metricsReducer,
-    bucketAggs: createBucketAggsReducer(datasource.timeField),
+    bucketAggs: createBucketAggsReducer(),
   });
 
   const dispatch = useStatelessReducer(
-    // timeField is part of the query model, but its value is always set to be the one from datasource settings.
-    (newState) => onStateChange({ ...query, ...newState, timeField: datasource.timeField }),
+    (newState) => onStateChange({ ...query, ...newState }),
     query,
     reducer
   );

--- a/src/configuration/mocks.ts
+++ b/src/configuration/mocks.ts
@@ -4,6 +4,7 @@ import { QuickwitOptions } from 'quickwit';
 
 export function createDefaultConfigOptions(): DataSourceSettings<QuickwitOptions> {
   return createDatasourceSettings<QuickwitOptions>({
+    timeField: 'timestamp',
     logMessageField: 'test.message',
     logLevelField: 'test.level',
     index: 'test',

--- a/src/configuration/mocks.ts
+++ b/src/configuration/mocks.ts
@@ -4,8 +4,6 @@ import { QuickwitOptions } from 'quickwit';
 
 export function createDefaultConfigOptions(): DataSourceSettings<QuickwitOptions> {
   return createDatasourceSettings<QuickwitOptions>({
-    timeField: 'timestamp',
-    timeOutputFormat: 'unix_timestamp_millisecs',
     logMessageField: 'test.message',
     logLevelField: 'test.level',
     index: 'test',

--- a/src/dataquery.gen.ts
+++ b/src/dataquery.gen.ts
@@ -395,10 +395,6 @@ export interface Elasticsearch extends DataQuery {
    * Lucene query
    */
   query?: string;
-  /**
-   * Name of time field
-   */
-  timeField?: string;
 }
 
 export const defaultElasticsearch: Partial<Elasticsearch> = {

--- a/src/dataquery.gen.ts
+++ b/src/dataquery.gen.ts
@@ -395,7 +395,7 @@ export interface Elasticsearch extends DataQuery {
    * Lucene query
    */
   query?: string;
-    /**
+  /**
    * Name of time field
    */
   timeField?: string;

--- a/src/dataquery.gen.ts
+++ b/src/dataquery.gen.ts
@@ -395,6 +395,10 @@ export interface Elasticsearch extends DataQuery {
    * Lucene query
    */
   query?: string;
+    /**
+   * Name of time field
+   */
+  timeField?: string;
 }
 
 export const defaultElasticsearch: Partial<Elasticsearch> = {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -113,7 +113,12 @@ export class QuickwitDataSource
       };
     }
     const backendCheck = from(this.callHealthCheck()).pipe(
-      mergeMap((res) => of(res))
+      mergeMap((res) => {
+        return of({
+          status: res.status.toLowerCase(),
+          message: res.message
+        })
+      })
     )
 
     return lastValueFrom(backendCheck)

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -70,6 +70,7 @@ export class QuickwitDataSource
     DataSourceWithQueryImportSupport<ElasticsearchQuery>
 {
   index: string;
+  timeField: string;
   logMessageField?: string;
   logLevelField?: string;
   dataLinks: DataLinkConfig[];
@@ -84,6 +85,7 @@ export class QuickwitDataSource
     super(instanceSettings);
     const settingsData = instanceSettings.jsonData || ({} as QuickwitOptions);
     this.index = settingsData.index || '';
+    this.timeField = ''
     this.logMessageField = settingsData.logMessageField || '';
     this.logLevelField = settingsData.logLevelField || '';
     this.dataLinks = settingsData.dataLinks || [];
@@ -175,6 +177,7 @@ export class QuickwitDataSource
           return undefined;
         }
         const bucketAggs: BucketAggregation[] = [];
+        const timeField = this.timeField ?? 'timestamp';
 
         if (this.logLevelField) {
           bucketAggs.push({
@@ -197,6 +200,7 @@ export class QuickwitDataSource
             min_doc_count: '0',
             trimEdges: '0',
           },
+          field: timeField,
         });
 
         return {

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -38,6 +38,7 @@ export function createElasticDatasource(
     access: 'proxy',
     url: '',
     jsonData: {
+      timeField: '',
       index: '',
       ...jsonData,
     },

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -38,8 +38,6 @@ export function createElasticDatasource(
     access: 'proxy',
     url: '',
     jsonData: {
-      timeField: '',
-      timeOutputFormat: '',
       index: '',
       ...jsonData,
     },

--- a/src/quickwit.ts
+++ b/src/quickwit.ts
@@ -2,8 +2,6 @@ import { DataSourceJsonData } from "@grafana/data";
 import { DataLinkConfig } from "./types";
 
 export interface QuickwitOptions extends DataSourceJsonData {
-    timeField: string;
-    timeOutputFormat: string;
     interval?: Interval;
     logMessageField?: string;
     logLevelField?: string;

--- a/src/quickwit.ts
+++ b/src/quickwit.ts
@@ -2,6 +2,7 @@ import { DataSourceJsonData } from "@grafana/data";
 import { DataLinkConfig } from "./types";
 
 export interface QuickwitOptions extends DataSourceJsonData {
+    timeField: string;
     interval?: Interval;
     logMessageField?: string;
     logLevelField?: string;


### PR DESCRIPTION
- Leverage the `ds_query` path in `getTerms` instead of building an elastic query
- Let the backend convert the TimeRange to a rangeQuery 
- Default time field in BucketAggEditor is removed. [backend still performs the query with ds configured timeField as a default for date_histogram](https://github.com/quickwit-oss/quickwit-datasource/blob/2098ac3033f2a0ec5e4e3df533f3779166af4a95/pkg/quickwit/data_query.go#L171)