### PR TITLE
Use hit's sort field as proxy for the timestamp

### DIFF
--- a/pkg/quickwit/client/client.go
+++ b/pkg/quickwit/client/client.go
@@ -26,10 +26,9 @@ type DatasourceInfo struct {
 }
 
 type ConfiguredFields struct {
-	TimeField        string
-	TimeOutputFormat string
-	LogMessageField  string
-	LogLevelField    string
+	TimeField       string
+	LogMessageField string
+	LogLevelField   string
 }
 
 // Client represents a client which can interact with elasticsearch api

--- a/pkg/quickwit/error_handling_test.go
+++ b/pkg/quickwit/error_handling_test.go
@@ -39,10 +39,9 @@ func TestErrorAvgMissingField(t *testing.T) {
 	`)
 
 	configuredFields := es.ConfiguredFields{
-		TimeOutputFormat: Rfc3339,
-		TimeField:        "testtime",
-		LogMessageField:  "line",
-		LogLevelField:    "lvl",
+		TimeField:       "testtime",
+		LogMessageField: "line",
+		LogLevelField:   "lvl",
 	}
 
 	result, err := queryDataTestWithResponseCode(query, 400, response, configuredFields)
@@ -72,10 +71,9 @@ func TestErrorAvgMissingFieldNoDetailedErrors(t *testing.T) {
 	`)
 
 	configuredFields := es.ConfiguredFields{
-		TimeOutputFormat: Rfc3339,
-		TimeField:        "testtime",
-		LogMessageField:  "line",
-		LogLevelField:    "lvl",
+		TimeField:       "testtime",
+		LogMessageField: "line",
+		LogLevelField:   "lvl",
 	}
 
 	result, err := queryDataTestWithResponseCode(query, 400, response, configuredFields)
@@ -119,10 +117,9 @@ func TestErrorTooManyDateHistogramBuckets(t *testing.T) {
 	`)
 
 	configuredFields := es.ConfiguredFields{
-		TimeOutputFormat: Rfc3339,
-		TimeField:        "testtime",
-		LogMessageField:  "line",
-		LogLevelField:    "lvl",
+		TimeField:       "testtime",
+		LogMessageField: "line",
+		LogLevelField:   "lvl",
 	}
 	result, err := queryDataTestWithResponseCode(query, 200, response, configuredFields)
 	require.NoError(t, err)
@@ -157,10 +154,9 @@ func TestNonElasticError(t *testing.T) {
 	response := []byte(`Access to the database is forbidden`)
 
 	configuredFields := es.ConfiguredFields{
-		TimeOutputFormat: Rfc3339,
-		TimeField:        "testtime",
-		LogMessageField:  "line",
-		LogLevelField:    "lvl",
+		TimeField:       "testtime",
+		LogMessageField: "line",
+		LogLevelField:   "lvl",
 	}
 
 	result, err := queryDataTestWithResponseCode(query, 403, response, configuredFields)

--- a/pkg/quickwit/models.go
+++ b/pkg/quickwit/models.go
@@ -122,13 +122,3 @@ func describeMetric(metricType, field string) string {
 	}
 	return text + " " + field
 }
-
-const (
-	Iso8601         string = "iso8601"
-	Rfc2822         string = "rfc2822"
-	Rfc3339         string = "rfc3339"
-	TimestampSecs   string = "unix_timestamp_secs"
-	TimestampMillis string = "unix_timestamp_millis"
-	TimestampMicros string = "unix_timestamp_micros"
-	TimestampNanos  string = "unix_timestamp_nanos"
-)

--- a/pkg/quickwit/querydata_test.go
+++ b/pkg/quickwit/querydata_test.go
@@ -144,10 +144,9 @@ func queryDataTestWithResponseCode(queriesBytes []byte, responseStatusCode int, 
 
 func queryDataTest(queriesBytes []byte, responseBytes []byte) (queryDataTestResult, error) {
 	configuredFields := es.ConfiguredFields{
-		TimeOutputFormat: Rfc3339,
-		TimeField:        "testtime",
-		LogMessageField:  "line",
-		LogLevelField:    "lvl",
+		TimeField:       "testtime",
+		LogMessageField: "line",
+		LogLevelField:   "lvl",
 	}
 	return queryDataTestWithResponseCode(queriesBytes, 200, responseBytes, configuredFields)
 }

--- a/pkg/quickwit/quickwit.go
+++ b/pkg/quickwit/quickwit.go
@@ -57,7 +57,6 @@ func NewQuickwitDatasource(settings backend.DataSourceInstanceSettings) (instanc
 	}
 
 	timeField, toOk := jsonData["timeField"].(string)
-	timeOutputFormat, tofOk := jsonData["timeOutputFormat"].(string)
 
 	logLevelField, ok := jsonData["logLevelField"].(string)
 	if !ok {
@@ -91,18 +90,17 @@ func NewQuickwitDatasource(settings backend.DataSourceInstanceSettings) (instanc
 		maxConcurrentShardRequests = 256
 	}
 
-	if !toOk || !tofOk {
-		timeField, timeOutputFormat, err = GetTimestampFieldInfos(index, settings.URL, httpCli)
+	if !toOk {
+		timeField, err = GetTimestampFieldInfos(index, settings.URL, httpCli)
 		if nil != err {
 			return nil, err
 		}
 	}
 
 	configuredFields := es.ConfiguredFields{
-		TimeField:        timeField,
-		TimeOutputFormat: timeOutputFormat,
-		LogLevelField:    logLevelField,
-		LogMessageField:  logMessageField,
+		TimeField:       timeField,
+		LogLevelField:   logLevelField,
+		LogMessageField: logMessageField,
 	}
 
 	model := es.DatasourceInfo{

--- a/pkg/quickwit/response_parser.go
+++ b/pkg/quickwit/response_parser.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"golang.org/x/exp/slices"
 
 	es "github.com/quickwit-oss/quickwit-datasource/pkg/quickwit/client"
 	"github.com/quickwit-oss/quickwit-datasource/pkg/quickwit/simplejson"
@@ -261,7 +260,7 @@ func processDocsToDataFrameFields(docs []map[string]interface{}, propNames []str
 		if propName == configuredFields.TimeField {
 			timeVector := make([]*time.Time, size)
 			for i, doc := range docs {
-				timeValue, err := ParseToTime(doc["sort"].([]any)[0], TimestampNanos)
+				timeValue, err := ParseToTime(doc["sort"].([]any)[0])
 				if err != nil {
 					continue
 				}
@@ -308,38 +307,13 @@ func processDocsToDataFrameFields(docs []map[string]interface{}, propNames []str
 // Parses a value into Time given a timeOutputFormat. The conversion
 // only works with float64 as this is what we get when parsing a response.
 // TODO: understand why we get a float64?
-func ParseToTime(value interface{}, timeOutputFormat string) (time.Time, error) {
-	if timeOutputFormat == Iso8601 || timeOutputFormat == Rfc3339 {
-		value_string := value.(string)
-		timeValue, err := time.Parse(time.RFC3339, value_string)
-		if err != nil {
-			return time.Time{}, err
-		}
-		return timeValue, nil
-	} else if timeOutputFormat == Rfc2822 {
-		value_string := value.(string)
-		timeValue, err := time.Parse(time.RFC822Z, value_string)
-		if err != nil {
-			return time.Time{}, err
-		}
-		return timeValue, nil
-	} else if slices.Contains([]string{TimestampSecs, TimestampMillis, TimestampMicros, TimestampNanos}, timeOutputFormat) {
-		typed_value, ok := value.(float64)
-		if !ok {
-			return time.Time{}, errors.New("parse time only accepts float64 with timestamp based format")
-		}
-		int64_value := int64(typed_value)
-		if timeOutputFormat == TimestampSecs {
-			return time.Unix(int64_value, 0), nil
-		} else if timeOutputFormat == TimestampMillis {
-			return time.Unix(0, int64_value*1_000_000), nil
-		} else if timeOutputFormat == TimestampMicros {
-			return time.Unix(0, int64_value*1_000), nil
-		} else if timeOutputFormat == TimestampNanos {
-			return time.Unix(0, int64_value), nil
-		}
+func ParseToTime(value interface{}) (time.Time, error) {
+	typed_value, ok := value.(float64)
+	if !ok {
+		return time.Time{}, errors.New("parse time only accepts float64 with timestamp based format")
 	}
-	return time.Time{}, fmt.Errorf("timeOutputFormat not supported yet %s", timeOutputFormat)
+	int64_value := int64(typed_value)
+	return time.Unix(0, int64_value), nil
 }
 
 func processBuckets(aggs map[string]interface{}, target *Query,

--- a/pkg/quickwit/response_parser.go
+++ b/pkg/quickwit/response_parser.go
@@ -175,7 +175,9 @@ func processRawDataResponse(res *es.SearchResponse, target *Query, configuredFie
 			flattened = flatten(hit["_source"].(map[string]interface{}))
 		}
 
-		doc := map[string]interface{}{}
+		doc := map[string]interface{}{
+			"sort": hit["sort"],
+		}
 
 		for k, v := range flattened {
 			doc[k] = v
@@ -259,7 +261,7 @@ func processDocsToDataFrameFields(docs []map[string]interface{}, propNames []str
 		if propName == configuredFields.TimeField {
 			timeVector := make([]*time.Time, size)
 			for i, doc := range docs {
-				timeValue, err := ParseToTime(doc[configuredFields.TimeField], configuredFields.TimeOutputFormat)
+				timeValue, err := ParseToTime(doc["sort"].([]any)[0], TimestampNanos)
 				if err != nil {
 					continue
 				}

--- a/pkg/quickwit/response_parser_qw_test.go
+++ b/pkg/quickwit/response_parser_qw_test.go
@@ -59,10 +59,9 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 			`)
 
 		configuredFields := es.ConfiguredFields{
-			TimeOutputFormat: TimestampNanos,
-			TimeField:        "testtime",
-			LogMessageField:  "line",
-			LogLevelField:    "lvl",
+			TimeField:       "testtime",
+			LogMessageField: "line",
+			LogLevelField:   "lvl",
 		}
 		result, _ := queryDataTestWithResponseCode(query, 200, response, configuredFields)
 		frames := result.response.Responses["A"].Frames
@@ -126,10 +125,9 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 			`)
 
 		configuredFields := es.ConfiguredFields{
-			TimeOutputFormat: TimestampMicros,
-			TimeField:        "testtime",
-			LogMessageField:  "line",
-			LogLevelField:    "lvl",
+			TimeField:       "testtime",
+			LogMessageField: "line",
+			LogLevelField:   "lvl",
 		}
 		result, _ := queryDataTestWithResponseCode(query, 200, response, configuredFields)
 		frames := result.response.Responses["A"].Frames
@@ -193,10 +191,9 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 			`)
 
 		configuredFields := es.ConfiguredFields{
-			TimeOutputFormat: TimestampMillis,
-			TimeField:        "testtime",
-			LogMessageField:  "line",
-			LogLevelField:    "lvl",
+			TimeField:       "testtime",
+			LogMessageField: "line",
+			LogLevelField:   "lvl",
 		}
 		result, _ := queryDataTestWithResponseCode(query, 200, response, configuredFields)
 		frames := result.response.Responses["A"].Frames
@@ -260,10 +257,9 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 			`)
 
 		configuredFields := es.ConfiguredFields{
-			TimeOutputFormat: TimestampSecs,
-			TimeField:        "testtime",
-			LogMessageField:  "line",
-			LogLevelField:    "lvl",
+			TimeField:       "testtime",
+			LogMessageField: "line",
+			LogLevelField:   "lvl",
 		}
 		result, _ := queryDataTestWithResponseCode(query, 200, response, configuredFields)
 		frames := result.response.Responses["A"].Frames

--- a/pkg/quickwit/response_parser_qw_test.go
+++ b/pkg/quickwit/response_parser_qw_test.go
@@ -24,7 +24,8 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 						}
 					  ],
 					  "key": "Q-1561369883389-0.7611823271062786-0",
-					  "query": "hello AND message"
+					  "query": "hello AND message",
+						"sort":[{"testtime":"desc"}]
 					}
 				]
 			`)
@@ -46,7 +47,8 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 								"number": 1,
 								"line": "hello, i am a message",
 								"level": "debug",
-								"fields": { "lvl": "debug" }
+								"fields": { "lvl": "debug" },
+								"sort":[1684398201000000000]
 							  }
 							}
 						  ]
@@ -89,7 +91,8 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 						}
 					  ],
 					  "key": "Q-1561369883389-0.7611823271062786-0",
-					  "query": "hello AND message"
+					  "query": "hello AND message",
+						"sort":[{"testtime":"desc"}]
 					}
 				]
 			`)
@@ -112,7 +115,8 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 								"line": "hello, i am a message",
 								"level": "debug",
 								"fields": { "lvl": "debug" }
-							  }
+							  },
+								"sort":[1684398201000000000]
 							}
 						  ]
 						}
@@ -154,7 +158,8 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 						}
 					  ],
 					  "key": "Q-1561369883389-0.7611823271062786-0",
-					  "query": "hello AND message"
+					  "query": "hello AND message",
+						"sort":[{"testtime":"desc"}]
 					}
 				]
 			`)
@@ -177,7 +182,8 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 								"line": "hello, i am a message",
 								"level": "debug",
 								"fields": { "lvl": "debug" }
-							  }
+							  },
+								"sort":[1684398201000000000]
 							}
 						  ]
 						}
@@ -219,7 +225,8 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 						}
 					  ],
 					  "key": "Q-1561369883389-0.7611823271062786-0",
-					  "query": "hello AND message"
+					  "query": "hello AND message",
+						"sort":[{"testtime":"desc"}]
 					}
 				]
 			`)
@@ -242,7 +249,8 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 								"line": "hello, i am a message",
 								"level": "debug",
 								"fields": { "lvl": "debug" }
-							  }
+							  },
+								"sort":[1684398201000000000]
 							}
 						  ]
 						}

--- a/pkg/quickwit/response_parser_qw_test.go
+++ b/pkg/quickwit/response_parser_qw_test.go
@@ -276,27 +276,9 @@ func TestProcessLogsResponseWithDifferentTimeOutputFormat(t *testing.T) {
 }
 
 func TestConvertToTime(t *testing.T) {
-	t.Run("Test parse unix timestamps secs", func(t *testing.T) {
-		inputValue := interface{}(1234567890.0)
-		value, _ := ParseToTime(inputValue, "unix_timestamp_secs")
-		require.Equal(t, time.Unix(1234567890, 0), value)
-	})
-
-	t.Run("Test parse unix timestamps millisecs", func(t *testing.T) {
-		inputValue := interface{}(1234567890000.0)
-		value, _ := ParseToTime(inputValue, "unix_timestamp_millis")
-		require.Equal(t, time.Unix(1234567890, 0), value)
-	})
-
-	t.Run("Test parse unix timestamps microsecs", func(t *testing.T) {
-		inputValue := interface{}(1234567890000000.0)
-		value, _ := ParseToTime(inputValue, "unix_timestamp_micros")
-		require.Equal(t, time.Unix(1234567890, 0), value)
-	})
-
-	t.Run("Test parse unix timestamps nanosecs", func(t *testing.T) {
+	t.Run("Test parse unix timestamps nanosecs of float type", func(t *testing.T) {
 		inputValue := interface{}(1234567890000000000.0)
-		value, _ := ParseToTime(inputValue, "unix_timestamp_nanos")
+		value, _ := ParseToTime(inputValue)
 		require.Equal(t, time.Unix(1234567890, 0), value)
 	})
 }

--- a/pkg/quickwit/response_parser_test.go
+++ b/pkg/quickwit/response_parser_test.go
@@ -33,7 +33,8 @@ func TestProcessLogsResponse(t *testing.T) {
 						}
 					  ],
 					  "key": "Q-1561369883389-0.7611823271062786-0",
-					  "query": "hello AND message"
+					  "query": "hello AND message",
+						"sort":[{"testtime":"desc"}]
 					}
 				]
 			`)
@@ -61,7 +62,8 @@ func TestProcessLogsResponse(t *testing.T) {
 								"message": [
 								  "@HIGHLIGHT@hello@/HIGHLIGHT@, i am a @HIGHLIGHT@message@/HIGHLIGHT@"
 								]
-							  }
+							  },
+								"sort":[1684398201000000000]
 							},
 							{
 							  "_id": "kdospaidopa",
@@ -79,7 +81,8 @@ func TestProcessLogsResponse(t *testing.T) {
 								"message": [
 								  "@HIGHLIGHT@hello@/HIGHLIGHT@, i am a @HIGHLIGHT@message@/HIGHLIGHT@"
 								]
-							  }
+							  },
+								"sort":[1684398201000000000]
 							}
 						  ]
 						}
@@ -374,7 +377,7 @@ func TestProcessRawDataResponse(t *testing.T) {
 										"xyz": null
   			          },
   			          "sort":[
-  			            1675869055830,
+				            1675869055830000000,
   			            4
   			          ]
   			        },
@@ -406,7 +409,7 @@ func TestProcessRawDataResponse(t *testing.T) {
 										"xyz": "def"
   			          },
   			          "sort":[
-  			            1675869054835,
+				            1675869054835000000,
   			            7
   			          ]
   			        }
@@ -427,7 +430,7 @@ func TestProcessRawDataResponse(t *testing.T) {
 		require.Len(t, dataframes, 1)
 		frame := dataframes[0]
 
-		require.Equal(t, 10, len(frame.Fields))
+		require.Equal(t, 11, len(frame.Fields))
 		// Fields have the correct length
 		require.Equal(t, 2, frame.Fields[0].Len())
 		// First field is timeField
@@ -440,7 +443,7 @@ func TestProcessRawDataResponse(t *testing.T) {
 		require.Equal(t, "nested.field.double_nested", frame.Fields[7].Name)
 		require.Equal(t, data.FieldTypeNullableString, frame.Fields[7].Type())
 		// Correctly detects type even if first value is null
-		require.Equal(t, data.FieldTypeNullableString, frame.Fields[9].Type())
+		require.Equal(t, data.FieldTypeNullableString, frame.Fields[10].Type())
 	})
 
 	t.Run("Raw data query filterable fields", func(t *testing.T) {

--- a/pkg/quickwit/response_parser_test.go
+++ b/pkg/quickwit/response_parser_test.go
@@ -3287,10 +3287,9 @@ func parseTestResponse(tsdbQueries map[string]string, responseBody string) (*bac
 	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
 	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
 	configuredFields := es.ConfiguredFields{
-		TimeOutputFormat: Rfc3339,
-		TimeField:        "@timestamp",
-		LogMessageField:  "line",
-		LogLevelField:    "lvl",
+		TimeField:       "@timestamp",
+		LogMessageField: "line",
+		LogLevelField:   "lvl",
 	}
 	timeRange := backend.TimeRange{
 		From: from,

--- a/pkg/quickwit/timestamp_infos.go
+++ b/pkg/quickwit/timestamp_infos.go
@@ -34,61 +34,30 @@ func NewErrorCreationPayload(statusCode int, message string) error {
 	return errors.New(string(json))
 }
 
-func FindTimeStampFormat(timestampFieldName string, parentName *string, fieldMappings []FieldMappings) *string {
-	if nil == fieldMappings {
-		return nil
-	}
-
-	for _, field := range fieldMappings {
-		fieldName := field.Name
-		if nil != parentName {
-			fieldName = fmt.Sprintf("%s.%s", *parentName, fieldName)
-		}
-
-		if field.Type == "datetime" && fieldName == timestampFieldName && nil != field.OutputFormat {
-			return field.OutputFormat
-		} else if field.Type == "object" && nil != field.FieldMappings {
-			format := FindTimeStampFormat(timestampFieldName, &field.Name, field.FieldMappings)
-			if nil != format {
-				return format
-			}
-		}
-	}
-
-	return nil
-}
-
-func DecodeTimestampFieldInfos(statusCode int, body []byte) (string, string, error) {
+func DecodeTimestampFieldInfos(statusCode int, body []byte) (string, error) {
 	var payload QuickwitMapping
 	err := json.Unmarshal(body, &payload)
 
 	if err != nil {
 		errMsg := fmt.Sprintf("Unmarshalling body error: err = %s, body = %s", err.Error(), (body))
 		qwlog.Error(errMsg)
-		return "", "", NewErrorCreationPayload(statusCode, errMsg)
+		return "", NewErrorCreationPayload(statusCode, errMsg)
 	}
 
 	timestampFieldName := payload.IndexConfig.DocMapping.TimestampField
-	timestampFieldFormat := FindTimeStampFormat(timestampFieldName, nil, payload.IndexConfig.DocMapping.FieldMappings)
 
-	if nil == timestampFieldFormat {
-		errMsg := fmt.Sprintf("No format found for field: %s", string(timestampFieldName))
-		qwlog.Error(errMsg)
-		return timestampFieldName, "", NewErrorCreationPayload(statusCode, errMsg)
-	}
-
-	qwlog.Info(fmt.Sprintf("Found timestampFieldName = %s, timestampFieldFormat = %s", timestampFieldName, *timestampFieldFormat))
-	return timestampFieldName, *timestampFieldFormat, nil
+	qwlog.Info(fmt.Sprintf("Found timestampFieldName = %s", timestampFieldName))
+	return timestampFieldName, nil
 }
 
-func GetTimestampFieldInfos(index string, qwUrl string, cli *http.Client) (string, string, error) {
+func GetTimestampFieldInfos(index string, qwUrl string, cli *http.Client) (string, error) {
 	mappingEndpointUrl := qwUrl + "/indexes/" + index
 	qwlog.Info("Calling quickwit endpoint: " + mappingEndpointUrl)
 	r, err := cli.Get(mappingEndpointUrl)
 	if err != nil {
 		errMsg := fmt.Sprintf("Error when calling url = %s: err = %s", mappingEndpointUrl, err.Error())
 		qwlog.Error(errMsg)
-		return "", "", err
+		return "", err
 	}
 
 	statusCode := r.StatusCode
@@ -96,7 +65,7 @@ func GetTimestampFieldInfos(index string, qwUrl string, cli *http.Client) (strin
 	if statusCode < 200 || statusCode >= 400 {
 		errMsg := fmt.Sprintf("Error when calling url = %s", mappingEndpointUrl)
 		qwlog.Error(errMsg)
-		return "", "", NewErrorCreationPayload(statusCode, errMsg)
+		return "", NewErrorCreationPayload(statusCode, errMsg)
 	}
 
 	defer r.Body.Close()
@@ -104,7 +73,7 @@ func GetTimestampFieldInfos(index string, qwUrl string, cli *http.Client) (strin
 	if err != nil {
 		errMsg := fmt.Sprintf("Error when calling url = %s: err = %s", mappingEndpointUrl, err.Error())
 		qwlog.Error(errMsg)
-		return "", "", NewErrorCreationPayload(statusCode, errMsg)
+		return "", NewErrorCreationPayload(statusCode, errMsg)
 	}
 
 	return DecodeTimestampFieldInfos(statusCode, body)

--- a/pkg/quickwit/timestamp_infos_test.go
+++ b/pkg/quickwit/timestamp_infos_test.go
@@ -69,12 +69,11 @@ func TestDecodeTimestampFieldInfos(t *testing.T) {
 			`)
 
 			// When
-			timestampFieldName, timestampFieldFormat, err := DecodeTimestampFieldInfos(200, query)
+			timestampFieldName, err := DecodeTimestampFieldInfos(200, query)
 
 			// Then
 			require.NoError(t, err)
 			require.Equal(t, timestampFieldName, "timestamp")
-			require.Equal(t, timestampFieldFormat, "rfc3339")
 		})
 
 		t.Run("Test decode nested fields", func(t *testing.T) {
@@ -144,158 +143,11 @@ func TestDecodeTimestampFieldInfos(t *testing.T) {
 			`)
 
 			// When
-			timestampFieldName, timestampFieldFormat, err := DecodeTimestampFieldInfos(200, query)
+			timestampFieldName, err := DecodeTimestampFieldInfos(200, query)
 
 			// Then
 			require.NoError(t, err)
 			require.Equal(t, timestampFieldName, "sub.timestamp")
-			require.Equal(t, timestampFieldFormat, "rfc3339")
-		})
-
-		t.Run("The timestamp field is not at the expected path", func(t *testing.T) {
-			// Given
-			query := []byte(`
-				{
-				  "version": "0.6",
-				  "index_uid": "myindex:01HG7ZZK3ZD7XF6BKQCZJHSJ5W",
-				  "index_config": {
-					"version": "0.6",
-					"index_id": "myindex",
-					"index_uri": "s3://quickwit-indexes/myindex",
-					"doc_mapping": {
-					  "field_mappings": [
-						{
-						  "name": "foo",
-						  "type": "text",
-						  "fast": false,
-						  "fieldnorms": false,
-						  "indexed": true,
-						  "record": "basic",
-						  "stored": true,
-						  "tokenizer": "default"
-						},
-						{
-							"name": "sub",
-							"type": "object",
-							"field_mappings": [
-							  {
-								"fast": true,
-								"fast_precision": "seconds",
-								"indexed": true,
-								"input_formats": [
-								  "rfc3339",
-								  "unix_timestamp"
-								],
-								"name": "timestamp",
-								"output_format": "rfc3339",
-								"stored": true,
-								"type": "datetime"
-							  }
-							]
-						}
-					  ],
-					  "tag_fields": [],
-					  "store_source": true,
-					  "index_field_presence": false,
-					  "timestamp_field": "timestamp",
-					  "mode": "dynamic",
-					  "dynamic_mapping": {},
-					  "partition_key": "foo",
-					  "max_num_partitions": 1,
-					  "tokenizers": []
-					},
-					"indexing_settings": {},
-					"search_settings": {
-					  "default_search_fields": [
-						"foo"
-					  ]
-					},
-					"retention": null
-				  },
-				  "checkpoint": {},
-				  "create_timestamp": 1701075471,
-				  "sources": []
-				}
-			`)
-
-			// When
-			_, _, err := DecodeTimestampFieldInfos(200, query)
-
-			// Then
-			require.Error(t, err)
-		})
-
-		t.Run("The timestamp field has not the right type", func(t *testing.T) {
-			// Given
-			query := []byte(`
-				{
-				  "version": "0.6",
-				  "index_uid": "myindex:01HG7ZZK3ZD7XF6BKQCZJHSJ5W",
-				  "index_config": {
-					"version": "0.6",
-					"index_id": "myindex",
-					"index_uri": "s3://quickwit-indexes/myindex",
-					"doc_mapping": {
-					  "field_mappings": [
-						{
-						  "name": "foo",
-						  "type": "text",
-						  "fast": false,
-						  "fieldnorms": false,
-						  "indexed": true,
-						  "record": "basic",
-						  "stored": true,
-						  "tokenizer": "default"
-						},
-						{
-							"name": "sub",
-							"type": "object",
-							"field_mappings": [
-							  {
-								"fast": true,
-								"fast_precision": "seconds",
-								"indexed": true,
-								"input_formats": [
-								  "rfc3339",
-								  "unix_timestamp"
-								],
-								"name": "timestamp",
-								"output_format": "rfc3339",
-								"stored": true,
-								"type": "whatever"
-							  }
-							]
-						}
-					  ],
-					  "tag_fields": [],
-					  "store_source": true,
-					  "index_field_presence": false,
-					  "timestamp_field": "sub.timestamp",
-					  "mode": "dynamic",
-					  "dynamic_mapping": {},
-					  "partition_key": "foo",
-					  "max_num_partitions": 1,
-					  "tokenizers": []
-					},
-					"indexing_settings": {},
-					"search_settings": {
-					  "default_search_fields": [
-						"foo"
-					  ]
-					},
-					"retention": null
-				  },
-				  "checkpoint": {},
-				  "create_timestamp": 1701075471,
-				  "sources": []
-				}
-			`)
-
-			// When
-			_, _, err := DecodeTimestampFieldInfos(200, query)
-
-			// Then
-			require.Error(t, err)
 		})
 	})
 }


### PR DESCRIPTION
Skip `timeOutputFormat` and use a known one.