### PR TITLE
Don't run query on editor change, fixes #70

### DIFF
--- a/src/components/QueryEditor/ElasticsearchQueryContext.test.tsx
+++ b/src/components/QueryEditor/ElasticsearchQueryContext.test.tsx
@@ -41,7 +41,6 @@ describe('ElasticsearchQueryContext', () => {
     // Should also set timeField to the configured `timeField` option in datasource configuration
     expect(changedQuery.timeField).toBe(datasource.timeField);
 
-    expect(onRunQuery).toHaveBeenCalled();
   });
 
   // the following applies to all hooks in ElasticsearchQueryContext as they all share the same code.

--- a/src/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/src/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -41,9 +41,8 @@ export const ElasticsearchProvider = ({
   const onStateChange = useCallback(
     (query: ElasticsearchQuery) => {
       onChange(query);
-      onRunQuery();
     },
-    [onChange, onRunQuery]
+    [onChange]
   );
 
   const reducer = combineReducers<Pick<ElasticsearchQuery, 'query' | 'alias' | 'metrics' | 'bucketAggs'>>({


### PR DESCRIPTION
Any query not run isn't persisted to history, and the plugin doesn't manage its own persistent state : a page refresh loses the current modifications.
That's a caveat I'm willing to accept for now.