### PR TITLE
Improve query modifications, skip implicit AND

### DIFF
--- a/src/datasource/base.ts
+++ b/src/datasource/base.ts
@@ -35,6 +35,7 @@ import { getQueryResponseProcessor } from 'datasource/processResponse';
 
 import { SECOND } from 'utils/time';
 import { GConstructor } from 'utils/mixins';
+import { LuceneQuery } from '@/utils/lucene';
 
 export type BaseQuickwitDataSourceConstructor = GConstructor<BaseQuickwitDataSource>
 
@@ -113,24 +114,18 @@ export class BaseQuickwitDataSource
       return query;
     }
 
-    let expression = query.query ?? '';
+    let lquery = LuceneQuery.parse(query.query ?? '')
     switch (action.type) {
       case 'ADD_FILTER': {
-        if (expression.length > 0) {
-          expression += ' AND ';
-        }
-        expression += `${action.options.key}:"${action.options.value}"`;
+        lquery = lquery.addFilter(action.options.key, action.options.value)
         break;
       }
       case 'ADD_FILTER_OUT': {
-        if (expression.length > 0) {
-          expression += ' AND ';
-        }
-        expression += `-${action.options.key}:"${action.options.value}"`;
+        lquery = lquery.addFilter(action.options.key, action.options.value, '-')
         break;
       }
     }
-    return { ...query, query: expression };
+    return { ...query, query: lquery.toString() };
   }
 
   getDataQueryRequest(queryDef: TermsQuery, range: TimeRange) {

--- a/src/utils/lucene.ts
+++ b/src/utils/lucene.ts
@@ -142,11 +142,15 @@ function removeNodeFromTree(ast: AST, node: NodeTerm): AST {
 /**
  * Merge a query with a filter.
  */
-export function concatenate(query: string, filter: string, condition = 'AND'): string {
+export function concatenate(query: string, filter: string, operator?: 'AND'|'OR'): string {
   if (!filter) {
     return query;
   }
-  return query.trim() === '' ? filter : `${query} ${condition} ${filter}`;
+  if (query.trim() === '' ) {
+    return filter;
+  }
+
+  return operator ? `${query} ${operator} ${filter}` : `${query} ${filter}`
 }
 
 export class LuceneQuery {


### PR DESCRIPTION
Our use of the default_operator parameter in the query allows us to rewrite ADD_FILTER operations without the "AND" operator. This, with the use of parentheses, should prevent producing queries that Quickwit can't parse.