### PR TITLE
Improve LuceneQueryEditor keyboard a11y, fixes #76

### DIFF
--- a/src/LogContext/components/LogContextUI.tsx
+++ b/src/LogContext/components/LogContextUI.tsx
@@ -64,7 +64,13 @@ export function LogContextUI(props: LogContextUIProps ){
         <LogContextQueryBuilderSidebar {...props} builder={builder} updateQuery={setParsedQuery} searchableFields={fields}/>
         <div className={css`width:100%; display:flex; flex-direction:column; gap:0.5rem; min-width:0;`}>
           {ActionBar}
-          <LuceneQueryEditor value={builder.query} autocompleter={getSuggestions} onChange={builder.setQuery}/>
+          <LuceneQueryEditor
+            placeholder="Shift-Enter to run the query, Ctrl-Space to autocomplete"
+            value={builder.query}
+            autocompleter={getSuggestions}
+            onChange={builder.setQuery}
+            onSubmit={()=>runQuery()}
+            />
         </div>
       </DatasourceContext.Provider>
     </div>

--- a/src/LogContext/components/LogContextUI.tsx
+++ b/src/LogContext/components/LogContextUI.tsx
@@ -69,7 +69,7 @@ export function LogContextUI(props: LogContextUIProps ){
             value={builder.query}
             autocompleter={getSuggestions}
             onChange={builder.setQuery}
-            onSubmit={()=>runQuery()}
+            onSubmit={runQuery}
             />
         </div>
       </DatasourceContext.Provider>

--- a/src/components/LuceneQueryEditor.tsx
+++ b/src/components/LuceneQueryEditor.tsx
@@ -1,6 +1,4 @@
 import React, { useRef, useCallback } from "react";
-import { debounceTime } from 'rxjs';
-import { useObservableCallback, useSubscription } from 'observable-hooks'
 import { css } from "@emotion/css";
 
 
@@ -50,10 +48,6 @@ export function LuceneQueryEditor(props: LuceneQueryEditorProps){
 
   const autocomplete = autocompletion({ override: [datasourceCompletions] })
 
-  const [onChange, textChanged$] = useObservableCallback<string>(event$ => event$.pipe(debounceTime(1000)))
-
-  useSubscription(textChanged$, props.onChange)
-
   return (<CodeMirror 
     ref={editorRef}
     className={css`height:100%`} // XXX : need to set height for both wrapper elements
@@ -61,7 +55,7 @@ export function LuceneQueryEditor(props: LuceneQueryEditorProps){
     theme={'dark'} 
     placeholder={props.placeholder}
     value={props.value}
-    onChange={onChange}
+    onChange={props.onChange}
     indentWithTab={false}
     extensions={[
       queryLinter, lintGutter(),

--- a/src/components/LuceneQueryEditor.tsx
+++ b/src/components/LuceneQueryEditor.tsx
@@ -4,7 +4,7 @@ import { useObservableCallback, useSubscription } from 'observable-hooks'
 import { css } from "@emotion/css";
 
 
-import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
+import CodeMirror, { ReactCodeMirrorRef, keymap } from '@uiw/react-codemirror';
 import {linter, Diagnostic, lintGutter} from "@codemirror/lint"
 import {autocompletion, CompletionContext} from "@codemirror/autocomplete"
 import { LuceneQuery } from "utils/lucene";
@@ -15,6 +15,7 @@ export type LuceneQueryEditorProps = {
   value: string,
   autocompleter: (word: string) => any,
   onChange: (query: string) => void
+  onSubmit: (query: string) => void
 }
 
 export function LuceneQueryEditor(props: LuceneQueryEditorProps){
@@ -61,6 +62,14 @@ export function LuceneQueryEditor(props: LuceneQueryEditorProps){
     placeholder={props.placeholder}
     value={props.value}
     onChange={onChange}
-    extensions={[queryLinter, lintGutter(), autocomplete]}
+    indentWithTab={false}
+    extensions={[
+      queryLinter, lintGutter(),
+      autocomplete,
+      keymap.of([{key:'Shift-Enter', run:(target)=>{
+        props.onSubmit(target.state.doc.toString())
+        return true;
+      }}])
+    ]}
     />);
 }

--- a/src/components/QueryEditor/AnnotationQueryEditor.tsx
+++ b/src/components/QueryEditor/AnnotationQueryEditor.tsx
@@ -34,6 +34,8 @@ export function ElasticsearchAnnotationsQueryEditor(props: Props) {
               target: newTarget,
             });
           }}
+          // XXX : ain't used at the moment, fix the build
+          onSubmit={()=>null}
         />
       </div>
 

--- a/src/components/QueryEditor/index.tsx
+++ b/src/components/QueryEditor/index.tsx
@@ -34,7 +34,7 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, range, ap
       query={query}
       range={range || getDefaultTimeRange()}
     >
-      <QueryEditorForm value={query} />
+      <QueryEditorForm value={query} onRunQuery={onRunQuery} />
     </ElasticsearchProvider>
   );
 };
@@ -54,21 +54,33 @@ export const useSearchableFields = getHook(SearchableFieldsContext)
 
 interface Props {
   value: ElasticsearchQuery;
+  onRunQuery: (query: string) => void
 }
 
-export const ElasticSearchQueryField = ({ value, onChange }: { value?: string; onChange: (v: string) => void }) => {
+type ElasticSearchQueryFieldProps = {
+  value?: string;
+  onChange: (v: string) => void
+  onSubmit: (v: string) => void
+}
+export const ElasticSearchQueryField = ({ value, onChange, onSubmit }: ElasticSearchQueryFieldProps) => {
   const styles = useStyles2(getStyles);
   const datasource = useDatasource()
   const { getSuggestions } = useDatasourceFields(datasource);
 
   return (
     <div className={styles.queryItem}>
-      <LuceneQueryEditor placeholder="Enter a lucene query" value={value || ''} autocompleter={getSuggestions} onChange={onChange}/>
+      <LuceneQueryEditor 
+        placeholder="Enter a lucene query - Type Shift-Enter to run query, Ctrl-Space to autocomplete"
+        value={value || ''}
+        autocompleter={getSuggestions}
+        onChange={onChange}
+        onSubmit={onSubmit}
+        />
     </div>
   );
 };
 
-const QueryEditorForm = ({ value }: Props) => {
+const QueryEditorForm = ({ value, onRunQuery }: Props) => {
   const dispatch = useDispatch();
   const nextId = useNextId();
   const styles = useStyles2(getStyles);
@@ -87,7 +99,7 @@ const QueryEditorForm = ({ value }: Props) => {
       </div>
       <div className={styles.root}>
         <InlineLabel width={17}>Lucene Query</InlineLabel>
-        <ElasticSearchQueryField onChange={(query) => dispatch(changeQuery(query))} value={value?.query} />
+        <ElasticSearchQueryField onChange={(query) => dispatch(changeQuery(query))} value={value?.query} onSubmit={onRunQuery} />
       </div>
 
       <MetricAggregationsEditor nextId={nextId} />

--- a/src/components/QueryEditor/index.tsx
+++ b/src/components/QueryEditor/index.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import React, { createContext } from 'react';
-import { debounceTime } from 'rxjs';
+import { debounceTime, throttleTime } from 'rxjs';
 import { useObservableCallback, useSubscription } from 'observable-hooks'
 
 import { CoreApp, Field, getDefaultTimeRange, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
@@ -100,7 +100,7 @@ const QueryEditorForm = ({ value, onRunQuery }: Props) => {
   }
 
   const [onChangeCB, textChanged$] = useObservableCallback<string>(event$ => event$.pipe(debounceTime(1000)))
-  const [onSubmitCB, submitted$] = useObservableCallback<string>(event$=>event$.pipe(debounceTime(500)))
+  const [onSubmitCB, submitted$] = useObservableCallback<string>(event$=>event$.pipe(throttleTime(500)))
 
   useSubscription(textChanged$, onChange)
   useSubscription(submitted$, onSubmit)


### PR DESCRIPTION
- Add `Shift-Enter` keymap to submit
- Tab focuses next element instead of indenting (don't create a keyboard trap, indent is not mission-critical)

TODO : 
- Add usage hints in the placeholder (`Ctrl-Space` to autocomplete, `Shift-Enter to submit)