### PR TITLE
Minor fixes to editor autocomplete

### DIFF
--- a/src/components/LuceneQueryEditor.tsx
+++ b/src/components/LuceneQueryEditor.tsx
@@ -36,17 +36,23 @@ export function LuceneQueryEditor(props: LuceneQueryEditorProps){
 
   const {autocompleter} = props;
   const datasourceCompletions = useCallback(async (context: CompletionContext)=>{
+    let suggestions;
     let word = context.matchBefore(/\S*/);
     if (!word){ return null }
-    const suggestions = await autocompleter(word?.text);
-    return {
-      from: word.from + suggestions.from,
-      options: suggestions.options
+      suggestions = await autocompleter(word?.text);
+    if (suggestions && suggestions.options.length > 0 ) {
+      return {
+        from: word.from + suggestions.from,
+        options: suggestions.options
+      }
     }
+    return null
   }, [autocompleter])
 
 
-  const autocomplete = autocompletion({ override: [datasourceCompletions] })
+  const autocomplete = autocompletion({
+    override: [datasourceCompletions]
+  })
 
   return (<CodeMirror 
     ref={editorRef}

--- a/src/datasource/utils.ts
+++ b/src/datasource/utils.ts
@@ -27,7 +27,7 @@ export function useDatasourceFields(datasource: QuickwitDataSource) {
   const getSuggestions = useCallback(async (word: string): Promise<Suggestion> => {
     let suggestions: Suggestion = { from: 0, options: [] };
 
-    const wordIsField = word.match(/([\w\.]+):"?(\S*)/);
+    const wordIsField = word.match(/([^:\s]+):"?([^"\s]*)"?/);
     if (wordIsField?.length) {
       const [_match, fieldName, _fieldValue] = wordIsField;
       const candidateValues = await datasource.getTagValues({ key: fieldName });


### PR DESCRIPTION
- Autocomplete can match `/` in fields (`lucene` parser still can't, this is _not_ a fix for #77)
- Handle empty fields/terms results gracefully