### PR TITLE
add timestamp field to plugin config editor

### DIFF
--- a/src/configuration/ConfigEditor.tsx
+++ b/src/configuration/ConfigEditor.tsx
@@ -91,6 +91,15 @@ export const QuickwitDetails = ({ value, onChange }: DetailsProps) => {
               width={40}
             />
           </InlineField>
+            <InlineField label="Timestamp field" labelWidth={26} tooltip="The timestamp field must be a fast field">
+                <Input
+                    id="quickwit_log_level_field"
+                    value={value.jsonData.timeField}
+                    onChange={(event) => onChange({ ...value, jsonData: {...value.jsonData, timeField: event.currentTarget.value}})}
+                    placeholder="timestamp"
+                    width={40}
+                />
+            </InlineField>
         </FieldSet>
       </div>
     </>


### PR DESCRIPTION
This allows configuring the timestamp field (`jsonData.timeField`) through the plugin config editor.
This setting is required for 'Forward OAuth Identity' config to work, because the call to `GetTimestampField` in `NewQuickwitDatasource` to autodetect the timestamp field from the index does not have the required oauth headers added to its HTTP request.