### PR TITLE
Enable annotations query editor

### DIFF
--- a/src/datasource/base.ts
+++ b/src/datasource/base.ts
@@ -70,6 +70,7 @@ export class BaseQuickwitDataSource
     this.logLevelField = settingsData.logLevelField || '';
     this.dataLinks = settingsData.dataLinks || [];
     this.languageProvider = new ElasticsearchLanguageProvider(this);
+    this.annotations = {};
   }
 
   query(request: DataQueryRequest<ElasticsearchQuery>): Observable<DataQueryResponse> {


### PR DESCRIPTION
`annotations` field needs to be set in the datasource constructor (just to `{}` if using the default settings) in order for annotation query editor to configure itself properly. See step 2 in docs: https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/enable-for-annotations

![image](https://github.com/quickwit-oss/quickwit-datasource/assets/56541/25db8c78-a21c-461a-ac9d-b83b1deea07d)
