### PR TITLE
Avoid resource leak in timestamp_infos

### DIFF
--- a/pkg/quickwit/timestamp_infos.go
+++ b/pkg/quickwit/timestamp_infos.go
@@ -54,6 +54,7 @@ func GetTimestampFieldFromIndex(index string, qwickwitUrl string, cli *http.Clie
 		qwlog.Error(errMsg)
 		return "", "", err
 	}
+	defer r.Body.Close()
 
 	statusCode := r.StatusCode
 
@@ -63,7 +64,6 @@ func GetTimestampFieldFromIndex(index string, qwickwitUrl string, cli *http.Clie
 		return "", "", NewErrorCreationPayload(statusCode, errMsg)
 	}
 
-	defer r.Body.Close()
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		errMsg := fmt.Sprintf("Error when calling url = %s: err = %s", mappingEndpointUrl, err.Error())
@@ -83,6 +83,7 @@ func GetTimestampFieldFromIndexPattern(indexPattern string, qwickwitUrl string, 
 		qwlog.Error(errMsg)
 		return "", "", err
 	}
+	defer r.Body.Close()
 
 	statusCode := r.StatusCode
 
@@ -92,7 +93,6 @@ func GetTimestampFieldFromIndexPattern(indexPattern string, qwickwitUrl string, 
 		return "", "", NewErrorCreationPayload(statusCode, errMsg)
 	}
 
-	defer r.Body.Close()
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		errMsg := fmt.Sprintf("Error when calling url = %s: err = %s", mappingEndpointUrl, err.Error())


### PR DESCRIPTION
`Response.Body` should be closed in any case

> If the returned error is nil, the [Response](https://pkg.go.dev/net/http#Response) will contain a non-nil Body which the user is expected to close. If the Body is not both read to EOF and closed, the [Client](https://pkg.go.dev/net/http#Client)'s underlying [RoundTripper](https://pkg.go.dev/net/http#RoundTripper) (typically [Transport](https://pkg.go.dev/net/http#Transport)) may not be able to re-use a persistent TCP connection to the server for a subsequent "keep-alive" request.

https://pkg.go.dev/net/http#Client.Do