### PR TITLE
Fix context range precision gap

### DIFF
--- a/src/LogContext/LogContextProvider.ts
+++ b/src/LogContext/LogContextProvider.ts
@@ -8,15 +8,14 @@ import {
   DataFrame,
   DataQueryError,
   DataQueryRequest,
-  dateTime,
   LogRowModel,
   rangeUtil,
-  TimeRange,
 } from '@grafana/data';
 
 import { ElasticsearchQuery, Logs, LogsSortDirection} from '../types';
 
 import { LogContextUI } from './components/LogContextUI';
+import { createContextTimeRange } from './utils';
 
 export interface LogRowContextOptions {
     direction?: LogRowContextQueryDirection;
@@ -25,18 +24,6 @@ export interface LogRowContextOptions {
 export enum LogRowContextQueryDirection {
     Backward = 'BACKWARD',
     Forward = 'FORWARD',
-}
-
-export function createContextTimeRange(rowTimeEpochMs: number, direction?: LogRowContextQueryDirection): TimeRange {
-  const offset = 7;
-  const timeFrom = dateTime(rowTimeEpochMs)
-  const timeTo = dateTime(rowTimeEpochMs)
-
-  const timeRange = {
-    from: (direction === LogRowContextQueryDirection.Forward) ? timeFrom.utc() : timeFrom.subtract(offset, 'hours').utc(),
-    to: (direction === LogRowContextQueryDirection.Backward) ? timeTo.utc() : timeTo.add(offset, 'hours').utc(),
-  }
-  return { ...timeRange, raw:timeRange }
 }
 
 export class LogContextProvider {

--- a/src/LogContext/components/LogContextUI.tsx
+++ b/src/LogContext/components/LogContextUI.tsx
@@ -11,7 +11,7 @@ import { DatasourceContext } from "@/components/QueryEditor/ElasticsearchQueryCo
 import { BaseQuickwitDataSource } from "@/datasource/base";
 import { useDatasourceFields } from "@/datasource/utils";
 import { Field, FieldContingency, Filter } from "../types";
-import { createContextTimeRange } from "LogContext/LogContextProvider";
+import { createContextTimeRange } from 'LogContext/utils';
 
 // TODO : define sensible defaults here
 // const excludedFields = [

--- a/src/LogContext/utils.test.ts
+++ b/src/LogContext/utils.test.ts
@@ -1,0 +1,15 @@
+import { LogRowContextQueryDirection } from "./LogContextProvider";
+import { createContextTimeRange } from "./utils";
+
+
+describe('Test LogContextProvider/utils:createContextTimeRange', () => {
+
+  it('Should produce a range overlapping target', () => {
+    const targetTimestampMicros = 1714062468704123
+    const targetTimestampMillis = 1714062468704
+    const range = createContextTimeRange(targetTimestampMillis, LogRowContextQueryDirection.Backward)
+
+    expect(range.from.toDate().getTime() * 1000).toBeLessThanOrEqual(targetTimestampMicros);
+    expect(range.to.toDate().getTime() * 1000).toBeGreaterThanOrEqual(targetTimestampMicros);
+  });
+});

--- a/src/LogContext/utils.ts
+++ b/src/LogContext/utils.ts
@@ -1,0 +1,20 @@
+import { dateTime, TimeRange } from "@grafana/data";
+import { LogRowContextQueryDirection } from './LogContextProvider';
+
+
+export function createContextTimeRange(rowTimeEpochMs: number, direction?: LogRowContextQueryDirection): TimeRange {
+  const offset = 7;
+  let timeFrom = dateTime(rowTimeEpochMs);
+  let timeTo = dateTime(rowTimeEpochMs);
+
+  if (direction === LogRowContextQueryDirection.Backward) {
+    // Add 1 to avoid missing results due to precision gap
+    timeTo = dateTime(rowTimeEpochMs + 1);
+  }
+
+  const timeRange = {
+    from: (direction === LogRowContextQueryDirection.Forward) ? timeFrom.utc() : timeFrom.subtract(offset, 'hours').utc(),
+    to: (direction === LogRowContextQueryDirection.Backward) ? timeTo.utc() : timeTo.add(offset, 'hours').utc(),
+  };
+  return { ...timeRange, raw: timeRange };
+}


### PR DESCRIPTION
When looking backwards on a searchAfter request, `createContextTimerange` creates a range which does not contain the searchAfter target timestamp `row.timeEpochNs` because of truncated precision.

This PR does the following : 
- offset the higher bound by 1 Ms to make sure that the target timestamp is within the bounds after truncation.
- add a test to check that scenario
