### PR TITLE
Use goroutine/chan to init, avoid hard failure

### DIFF
--- a/pkg/quickwit/client/client.go
+++ b/pkg/quickwit/client/client.go
@@ -16,6 +16,11 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
+type ReadyStatus struct {
+	IsReady bool
+	Err     error
+}
+
 type DatasourceInfo struct {
 	ID                         int64
 	HTTPClient                 *http.Client
@@ -23,7 +28,8 @@ type DatasourceInfo struct {
 	Database                   string
 	ConfiguredFields           ConfiguredFields
 	MaxConcurrentShardRequests int64
-	IsReady                    bool
+	ReadyStatus                chan ReadyStatus
+	ShouldInit                 bool
 }
 
 type ConfiguredFields struct {


### PR DESCRIPTION
Rework the deferred datasource initialization to use async channel/goroutine. This should avoid concurrent inits when two successive QueryData are requested.

Don't fail hard when output format is empty, log more stuff.