### PR TITLE
fix: Fix autocomplete for adhoc filters for grafana v11.x

### DIFF
--- a/build_and_start.sh
+++ b/build_and_start.sh
@@ -3,4 +3,4 @@
 npm install
 npm run build
 mage -v
-docker-compose up --build --force-recreate
+docker compose up --build --force-recreate

--- a/src/datasource/base.ts
+++ b/src/datasource/base.ts
@@ -199,12 +199,12 @@ export class BaseQuickwitDataSource
           .map(field_capability => {
             return {
               text: field_capability.field_name,
-              value: fieldTypeMap[field_capability.type],  
+              type: fieldTypeMap[field_capability.type],  
             }
           });
         const uniquefieldCapabilities = fieldCapabilities.filter((field_capability, index, self) =>
           index === self.findIndex((t) => (
-            t.text === field_capability.text && t.value === field_capability.value
+            t.text === field_capability.text && t.type === field_capability.type
           ))
         ).sort((a, b) => a.text.localeCompare(b.text));
         return uniquefieldCapabilities;


### PR DESCRIPTION
fixes #144 

My first PR, not too familiar with grafana scenes so I'm not sure where else to test but I've checked adhoc filters autocomplete on Grafana v10.4 and 11.4 and they were working correctly, please let me know if there are more places I should test.

### Changes
It seems like we were using one of the optional fields (value) on `MetricFindValue` to filter for field capabilities, but it seems like from v11.x (not sure which version exactly, I only checked v11.4 mentioned in the issue) Grafana is using the `value` field as the key for both the final query and the autocomplete for tags, which leads to:

- autocomplete fails because we're getting terms for field `"field" : "string"`
- final query having `string: <value>` which most of the time returns nothing

Fixed this by renaming the field used for field capabilities to `type`