### PR TITLE
Fix inconsistent field flattening

### DIFF
--- a/pkg/quickwit/response_parser.go
+++ b/pkg/quickwit/response_parser.go
@@ -1054,6 +1054,7 @@ func flatten(target map[string]interface{}) map[string]interface{} {
 			if shouldStepInside {
 				currentDepth++
 				step(v, newKey)
+				currentDepth--
 			} else {
 				output[newKey] = value
 			}

--- a/pkg/quickwit/response_parser_test.go
+++ b/pkg/quickwit/response_parser_test.go
@@ -3166,11 +3166,17 @@ func TestFlatten(t *testing.T) {
 					},
 				},
 			},
+			"other": map[string]interface{}{
+				"nested1": map[string]interface{}{
+					"nested2": "def",
+				},
+			},
 		}
 
 		flattened := flatten(obj)
-		require.Len(t, flattened, 1)
+		require.Len(t, flattened, 2)
 		require.Equal(t, map[string]interface{}{"nested11": map[string]interface{}{"nested12": "abc"}}, flattened["nested0.nested1.nested2.nested3.nested4.nested5.nested6.nested7.nested8.nested9.nested10"])
+		require.Equal(t, "def", flattened["other.nested1.nested2"])
 	})
 }
 


### PR DESCRIPTION
Hey, first-time contributor here.

I noticed log fields weren't being flattened consistently and kept randomly changing on every refresh.

After looking into it, I noticed the `flatten` function isn't tracking depth correctly: `currentDepth` is incremented before every recursive call but never decremented.
As a result, after 10 steps, any further fields don't get flattened, and since map iteration order is random, the result differs per log line and per request.

This fixes the issue by decrementing `currentDepth` after returning from the recursive call.
Alternatively, it might be worth considering if the depth limit is really needed here.
The function is only ever used to flatten JSON objects, so an infinite loop would be extremely unlikely/impossible.

Fixes #137