### PR TITLE
Fix panic when casting json.Number fields only present in some docs

### DIFF
--- a/pkg/quickwit/response_parser.go
+++ b/pkg/quickwit/response_parser.go
@@ -280,6 +280,9 @@ func processDocsToDataFrameFields(docs []map[string]interface{}, propNames []str
 			rawPropSlice := getDocPropSlice[json.Number](docs, propName, size)
 			propSlice := make([]*float64, size)
 			for i, val := range rawPropSlice {
+				if val == nil {
+					continue
+				}
 				val_f64, err := val.Float64()
 				if err == nil {
 					propSlice[i] = &val_f64


### PR DESCRIPTION
I noticed the backend plugin kept crashing on some queries.
The issue occurs when a field is missing from one or more documents, causing `Float64()` to be called on a null pointer.

This change adds a null check to prevent the panic.