### PR TITLE
feat: add quick filters

### DIFF
--- a/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/TermsSettingsEditor.test.tsx
+++ b/src/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/TermsSettingsEditor.test.tsx
@@ -22,6 +22,7 @@ describe('Terms Settings Editor', () => {
       query: '',
       bucketAggs: [termsAgg],
       metrics: [avg, derivative, topMetrics],
+      filters: [],
     };
 
     renderWithESProvider(<TermsSettingsEditor bucketAgg={termsAgg} />, { providerProps: { query } });

--- a/src/components/QueryEditor/ElasticsearchQueryContext.test.tsx
+++ b/src/components/QueryEditor/ElasticsearchQueryContext.test.tsx
@@ -13,6 +13,7 @@ const query: ElasticsearchQuery = {
   query: '',
   metrics: [{ id: '1', type: 'count' }],
   bucketAggs: [{ type: 'date_histogram', id: '2' }],
+  filters: []
 };
 
 describe('ElasticsearchQueryContext', () => {

--- a/src/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/src/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -8,6 +8,7 @@ import { ElasticsearchQuery } from '@/types';
 
 import { createReducer as createBucketAggsReducer } from './BucketAggregationsEditor/state/reducer';
 import { reducer as metricsReducer } from './MetricAggregationsEditor/state/reducer';
+import { reducer as filtersReducer } from './FilterEditor/state/reducer';
 import { aliasPatternReducer, queryReducer, initQuery, initExploreQuery } from './state';
 import { getHook } from '@/utils/context';
 import { Provider, useDispatch } from "react-redux";
@@ -64,10 +65,11 @@ export const ElasticsearchProvider = withStore(({
     [onChange]
   );
 
-  const reducer = combineReducers<Pick<ElasticsearchQuery, 'query' | 'alias' | 'metrics' | 'bucketAggs'>>({
+  const reducer = combineReducers<Pick<ElasticsearchQuery, 'query' | 'alias' | 'metrics' | 'filters' | 'bucketAggs'>>({
     query: queryReducer,
     alias: aliasPatternReducer,
     metrics: metricsReducer,
+    filters: filtersReducer,
     bucketAggs: createBucketAggsReducer(datasource.timeField),
   });
 
@@ -78,7 +80,7 @@ export const ElasticsearchProvider = withStore(({
     reducer
   );
 
-  const isUninitialized = !query.metrics || !query.bucketAggs || query.query === undefined;
+  const isUninitialized = !query.metrics || !query.filters || !query.bucketAggs || query.query === undefined;
 
   const [shouldRunInit, setShouldRunInit] = useState(isUninitialized);
 

--- a/src/components/QueryEditor/FilterEditor/index.tsx
+++ b/src/components/QueryEditor/FilterEditor/index.tsx
@@ -1,0 +1,149 @@
+import React, { useRef } from 'react';
+
+import { useDispatch } from '@/hooks/useStatelessReducer';
+import { IconButton } from '../../IconButton';
+import { useQuery } from '../ElasticsearchQueryContext';
+import { QueryEditorRow } from '../QueryEditorRow';
+
+import { QueryFilter } from '@/types';
+import { InlineSegmentGroup, Input, Segment, SegmentAsync, Tooltip } from '@grafana/ui';
+import {
+  addFilter,
+  removeFilter,
+  toggleFilterVisibility,
+  changeFilterField,
+  changeFilterOperation,
+  changeFilterValue,
+} from '@/components/QueryEditor/FilterEditor/state/actions';
+import { segmentStyles } from '@/components/QueryEditor/styles';
+import { useFields } from '@/hooks/useFields';
+import { newFilterId } from '@/utils/uid';
+import { filterOperations } from '@/queryDef';
+import { hasWhiteSpace, isSet } from '@/utils';
+
+interface FilterEditorProps {
+  onSubmit: () => void;
+}
+
+function filterErrors(filter: QueryFilter): string[] {
+  const errors: string[] = [];
+
+  if (!isSet(filter.filter.key)) {
+    errors.push('Field is not set');
+  }
+
+  if (!isSet(filter.filter.operator)) {
+    errors.push('Operator is not set');
+  }
+
+  if (!['exists', 'not exists'].includes(filter.filter.operator) && !isSet(filter.filter.value)) {
+    errors.push('Value is not set');
+  }
+
+  if (['term', 'not term'].includes(filter.filter.operator) && filter.filter.value && hasWhiteSpace(filter.filter.value)) {
+    errors.push('Term cannot have whitespace in value');
+  }
+
+  return errors;
+}
+
+export const FilterEditor = ({ onSubmit }: FilterEditorProps) => {
+  const dispatch = useDispatch();
+  const { filters } = useQuery();
+
+  return (
+    <>
+      {filters?.map((filter, index) => {
+        const errors = filterErrors(filter)
+        return (
+          <QueryEditorRow
+            key={`${filter.id}`}
+            label={errors.length > 0 ? (
+              <Tooltip content={errors.join('; ')}>
+                <span style={{color: "gray"}}>Filter</span>
+              </Tooltip>
+            ): 'Filter'}
+            hidden={filter.hide}
+            onHideClick={() => {
+              dispatch(toggleFilterVisibility(filter.id));
+              onSubmit();
+            }}
+            onRemoveClick={() => {
+              dispatch(removeFilter(filter.id));
+              onSubmit();
+            }}
+          >
+            <FilterEditorRow value={filter} onSubmit={onSubmit} />
+
+            {index === 0 && <IconButton
+              label="add"
+              iconName="plus"
+              style={{marginLeft: '4px'}}
+              onClick={() => dispatch(addFilter(newFilterId()))}
+            />}
+          </QueryEditorRow>
+        )
+      })}
+    </>
+  );
+};
+
+interface FilterEditorRowProps {
+  value: QueryFilter;
+  onSubmit: () => void;
+}
+
+export const FilterEditorRow = ({ value, onSubmit }: FilterEditorRowProps) => {
+  const dispatch = useDispatch();
+  const getFields = useFields('filters', 'startsWith');
+  const valueInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <InlineSegmentGroup>
+        <SegmentAsync
+          allowCustomValue={true}
+          className={segmentStyles}
+          loadOptions={getFields}
+          reloadOptionsOnChange={true}
+          onChange={(e) => {
+            dispatch(changeFilterField({ id: value.id, field: e.value ?? '' }));
+            if (['exists', 'not exists'].includes(value.filter.operator) || isSet(value.filter.value)) {
+              onSubmit();
+            }
+            // Auto focus the value input when a field is selected
+            setTimeout(() => valueInputRef.current?.focus(), 100);
+          }}
+          placeholder="Select Field"
+          value={value.filter.key}
+        />
+        <div style={{ whiteSpace: 'nowrap' }}>
+          <Segment
+            value={filterOperations.find((op) => op.value === value.filter.operator)}
+            options={filterOperations}
+            onChange={(e) => {
+              let op = e.value ?? filterOperations[0].value;
+              dispatch(changeFilterOperation({ id: value.id, op: op }));
+              if (['exists', 'not exists'].includes(op) || isSet(value.filter.value)) {
+                onSubmit();
+              }
+            }}
+          />
+        </div>
+        {!['exists', 'not exists'].includes(value.filter.operator) && (
+          <Input
+            ref={valueInputRef}
+            placeholder="Value"
+            value={value.filter.value}
+            onChange={(e) => dispatch(changeFilterValue({ id: value.id, value: e.currentTarget.value }))}
+            onKeyUp={(e) => {
+              if (e.key === 'Enter') {
+                onSubmit();
+              }
+            }}
+          />
+        )}
+      </InlineSegmentGroup>
+    </>
+  );
+};

--- a/src/components/QueryEditor/FilterEditor/index.tsx
+++ b/src/components/QueryEditor/FilterEditor/index.tsx
@@ -1,12 +1,13 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { useDispatch } from '@/hooks/useStatelessReducer';
 import { IconButton } from '../../IconButton';
-import { useQuery } from '../ElasticsearchQueryContext';
+import { useDatasource, useQuery, useRange } from '../ElasticsearchQueryContext';
 import { QueryEditorRow } from '../QueryEditorRow';
 
 import { QueryFilter } from '@/types';
-import { InlineSegmentGroup, Input, Segment, SegmentAsync, Tooltip } from '@grafana/ui';
+import { Icon, InlineSegmentGroup, Segment, SegmentAsync, Tooltip } from '@grafana/ui';
+import { MetricFindValue, SelectableValue } from '@grafana/data';
 import {
   addFilter,
   removeFilter,
@@ -18,7 +19,7 @@ import {
 import { segmentStyles } from '@/components/QueryEditor/styles';
 import { useFields } from '@/hooks/useFields';
 import { newFilterId } from '@/utils/uid';
-import { filterOperations } from '@/queryDef';
+import { categorizeFieldType, filterOperations, filterOperationsFor } from '@/queryDef';
 import { hasWhiteSpace, isSet } from '@/utils';
 
 interface FilterEditorProps {
@@ -95,8 +96,24 @@ interface FilterEditorRowProps {
 
 export const FilterEditorRow = ({ value, onSubmit }: FilterEditorRowProps) => {
   const dispatch = useDispatch();
+  const datasource = useDatasource();
+  const range = useRange();
   const getFields = useFields('filters', 'startsWith');
-  const valueInputRef = useRef<HTMLInputElement>(null);
+
+  const fieldCategory = categorizeFieldType(datasource.getFieldType?.(value.filter.key));
+  const visibleOperations = filterOperationsFor(fieldCategory);
+
+  const loadValues = async (query?: string): Promise<Array<SelectableValue<string>>> => {
+    if (!isSet(value.filter.key) || !datasource.getTagValues) {
+      return [];
+    }
+    const values: MetricFindValue[] = await datasource.getTagValues({ key: value.filter.key, timeRange: range });
+    const q = query?.toLowerCase();
+    return values
+      .map((v) => String(v.text))
+      .filter((text) => !q || text.toLowerCase().includes(q))
+      .map((text) => ({ label: text, value: text }));
+  };
 
   return (
     <>
@@ -107,20 +124,26 @@ export const FilterEditorRow = ({ value, onSubmit }: FilterEditorRowProps) => {
           loadOptions={getFields}
           reloadOptionsOnChange={true}
           onChange={(e) => {
-            dispatch(changeFilterField({ id: value.id, field: e.value ?? '' }));
+            const newKey = e.value ?? '';
+            dispatch(changeFilterField({ id: value.id, field: newKey }));
+            // If the currently selected operator isn't valid for the new field,
+            // reset it to the first valid one so the UI stays consistent.
+            const newCategory = categorizeFieldType(datasource.getFieldType?.(newKey));
+            const allowed = filterOperationsFor(newCategory);
+            if (!allowed.some((op) => op.value === value.filter.operator)) {
+              dispatch(changeFilterOperation({ id: value.id, op: allowed[0].value }));
+            }
             if (['exists', 'not exists'].includes(value.filter.operator) || isSet(value.filter.value)) {
               onSubmit();
             }
-            // Auto focus the value input when a field is selected
-            setTimeout(() => valueInputRef.current?.focus(), 100);
           }}
           placeholder="Select Field"
           value={value.filter.key}
         />
-        <div style={{ whiteSpace: 'nowrap' }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', gap: '4px', whiteSpace: 'nowrap' }}>
           <Segment
             value={filterOperations.find((op) => op.value === value.filter.operator)}
-            options={filterOperations}
+            options={visibleOperations}
             onChange={(e) => {
               let op = e.value ?? filterOperations[0].value;
               dispatch(changeFilterOperation({ id: value.id, op: op }));
@@ -129,17 +152,31 @@ export const FilterEditorRow = ({ value, onSubmit }: FilterEditorRowProps) => {
               }
             }}
           />
+          <Tooltip
+            content={
+              <div>
+                <div><strong>is</strong> / <strong>is not</strong> — phrase match. On a <em>keyword</em> field this is exact equality; on a <em>text</em> field it matches a contiguous sequence of tokens anywhere in the value.</div>
+                <div style={{ marginTop: 4 }}><strong>contains</strong> / <strong>does not contain</strong> — single-token match (no whitespace allowed). On a <em>keyword</em> field this is exact equality; on a <em>text</em> field it matches any document whose analyzed tokens include this term. Not a substring match — &ldquo;germ&rdquo; will not match &ldquo;germany&rdquo;.</div>
+                <div style={{ marginTop: 4 }}><strong>&gt;</strong> / <strong>&lt;</strong> — numeric or date range. Shown only for numeric and date fields.</div>
+                <div style={{ marginTop: 4 }}><strong>exists</strong> / <strong>does not exist</strong> — presence check, no value needed.</div>
+              </div>
+            }
+            placement="top"
+          >
+            <Icon name="info-circle" size="xs" style={{ cursor: 'help', opacity: 0.6 }} />
+          </Tooltip>
         </div>
         {!['exists', 'not exists'].includes(value.filter.operator) && (
-          <Input
-            ref={valueInputRef}
+          <SegmentAsync
+            allowCustomValue={true}
+            className={segmentStyles}
+            loadOptions={loadValues}
+            reloadOptionsOnChange={true}
             placeholder="Value"
             value={value.filter.value}
-            onChange={(e) => dispatch(changeFilterValue({ id: value.id, value: e.currentTarget.value }))}
-            onKeyUp={(e) => {
-              if (e.key === 'Enter') {
-                onSubmit();
-              }
+            onChange={(e) => {
+              dispatch(changeFilterValue({ id: value.id, value: e.value ?? '' }));
+              onSubmit();
             }}
           />
         )}

--- a/src/components/QueryEditor/FilterEditor/state/actions.ts
+++ b/src/components/QueryEditor/FilterEditor/state/actions.ts
@@ -1,0 +1,10 @@
+import { createAction } from '@reduxjs/toolkit';
+
+import { QueryFilter } from '@/types';
+
+export const addFilter = createAction<QueryFilter['id']>('@filters/add');
+export const removeFilter = createAction<QueryFilter['id']>('@filters/remove');
+export const toggleFilterVisibility = createAction<QueryFilter['id']>('@filters/toggle_visibility');
+export const changeFilterField = createAction<{ id: QueryFilter['id']; field: string }>('@filters/change_field');
+export const changeFilterValue = createAction<{ id: QueryFilter['id']; value: string }>('@filters/change_value');
+export const changeFilterOperation = createAction<{ id: QueryFilter['id']; op: string }>('@filters/change_operation');

--- a/src/components/QueryEditor/FilterEditor/state/reducer.ts
+++ b/src/components/QueryEditor/FilterEditor/state/reducer.ts
@@ -1,0 +1,100 @@
+import { Action } from '@reduxjs/toolkit';
+import { defaultFilter } from '@/queryDef';
+import { ElasticsearchQuery } from '@/types';
+import { initExploreQuery, initQuery } from '../../state';
+
+import {
+  addFilter,
+  changeFilterField,
+  changeFilterOperation,
+  changeFilterValue,
+  removeFilter,
+  toggleFilterVisibility,
+} from './actions';
+
+export const reducer = (state: ElasticsearchQuery['filters'], action: Action): ElasticsearchQuery['filters'] => {
+  // console.log('Running filters reducer with action:', action, state);
+
+  if (addFilter.match(action)) {
+    return [...state!, defaultFilter(action.payload)];
+  }
+
+  if (removeFilter.match(action)) {
+    const filterToRemove = state!.find((m) => m.id === action.payload)!;
+    const resultingFilters = state!.filter((filter) => filterToRemove.id !== filter.id);
+    if (resultingFilters.length === 0) {
+      return [defaultFilter()];
+    }
+    return resultingFilters;
+  }
+
+  if (changeFilterField.match(action)) {
+    return state!.map((filter) => {
+      if (filter.id !== action.payload.id) {
+        return filter;
+      }
+
+      return {
+        ...filter,
+        filter: {
+          ...filter.filter,
+          key: action.payload.field,
+        }
+      };
+    });
+  }
+
+  if (changeFilterOperation.match(action)) {
+    return state!.map((filter) => {
+      if (filter.id !== action.payload.id) {
+        return filter;
+      }
+
+      return {
+        ...filter,
+        filter: {
+          ...filter.filter,
+          operator: action.payload.op,
+        }
+      };
+    });
+  }
+
+  if (changeFilterValue.match(action)) {
+    return state!.map((filter) => {
+      if (filter.id !== action.payload.id) {
+        return filter;
+      }
+
+      return {
+        ...filter,
+        filter: {
+          ...filter.filter,
+          value: action.payload.value,
+        }
+      };
+    });
+  }
+
+  if (toggleFilterVisibility.match(action)) {
+    return state!.map((filter) => {
+      if (filter.id !== action.payload) {
+        return filter;
+      }
+
+      return {
+        ...filter,
+        hide: !filter.hide,
+      };
+    });
+  }
+
+  if (initQuery.match(action) || initExploreQuery.match(action)) {
+    if (state && state.length > 0) {
+      return state;
+    }
+    return [defaultFilter()];
+  }
+
+  return state;
+};

--- a/src/components/QueryEditor/FilterEditor/state/reducer.ts
+++ b/src/components/QueryEditor/FilterEditor/state/reducer.ts
@@ -13,7 +13,6 @@ import {
 } from './actions';
 
 export const reducer = (state: ElasticsearchQuery['filters'], action: Action): ElasticsearchQuery['filters'] => {
-  // console.log('Running filters reducer with action:', action, state);
 
   if (addFilter.match(action)) {
     return [...state!, defaultFilter(action.payload)];

--- a/src/components/QueryEditor/MetricAggregationsEditor/MetricEditor.test.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/MetricEditor.test.tsx
@@ -24,6 +24,7 @@ describe('Metric Editor', () => {
       query: '',
       metrics: [avg],
       bucketAggs: [defaultBucketAgg('2')],
+      filters: [],
     };
 
     const getFields: ElasticDatasource['getFields'] = jest.fn(() => from([[]]));
@@ -62,6 +63,7 @@ describe('Metric Editor', () => {
       query: '',
       metrics: [count],
       bucketAggs: [],
+      filters: [],
     };
 
     const wrapper = ({ children }: PropsWithChildren<{}>) => (

--- a/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
+++ b/src/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
@@ -27,6 +27,7 @@ describe('Settings Editor', () => {
           },
         ],
         bucketAggs: [],
+        filters: [],
       };
 
       const onChange = jest.fn();
@@ -102,6 +103,7 @@ describe('Settings Editor', () => {
           },
         ],
         bucketAggs: [],
+        filters: [],
       };
 
       const onChange = jest.fn();

--- a/src/components/QueryEditor/index.test.tsx
+++ b/src/components/QueryEditor/index.test.tsx
@@ -20,6 +20,7 @@ describe('QueryEditor', () => {
       ],
       // Even if present, this shouldn't be shown in the UI
       bucketAggs: [{ id: '2', type: 'date_histogram' }],
+      filters: [],
     };
 
     render(<QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={noop} onRunQuery={noop} />);
@@ -38,6 +39,7 @@ describe('QueryEditor', () => {
         },
       ],
       bucketAggs: [{ id: '2', type: 'date_histogram' }],
+      filters: [],
     };
 
     render(<QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={noop} onRunQuery={noop} />);

--- a/src/components/QueryEditor/index.tsx
+++ b/src/components/QueryEditor/index.tsx
@@ -25,6 +25,7 @@ import { QueryTypeSelector } from './QueryTypeSelector';
 import { getHook } from '@/utils/context';
 import { LuceneQueryEditor } from '@/components/LuceneQueryEditor';
 import { useDatasourceFields } from '@/datasource/utils';
+import { FilterEditor } from '@/components/QueryEditor/FilterEditor';
 
 export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchQuery, QuickwitOptions>;
 
@@ -133,6 +134,7 @@ const QueryEditorForm = ({ value, onRunQuery }: Props) => {
           value={value?.query}
           onSubmit={onSubmitCB}/>
       </div>
+      <FilterEditor onSubmit={onRunQuery} />
 
       <MetricAggregationsEditor nextId={nextId} />
       {showBucketAggregationsEditor && <BucketAggregationsEditor nextId={nextId} />}

--- a/src/dataquery.gen.ts
+++ b/src/dataquery.gen.ts
@@ -9,6 +9,7 @@
 // Run 'make gen-cue' from repository root to regenerate.
 
 import { DataQuery } from '@grafana/schema';
+import { AdHocVariableFilter } from '@grafana/data';
 
 export const DataQueryModelVersion = Object.freeze([0, 0]);
 
@@ -126,6 +127,12 @@ export interface BaseMetricAggregation {
   hide?: boolean;
   id: string;
   type: MetricAggregationType;
+}
+
+export interface QueryFilter {
+  hide?: boolean;
+  id: string;
+  filter: AdHocVariableFilter;
 }
 
 export interface PipelineVariable {
@@ -393,6 +400,10 @@ export interface Elasticsearch extends DataQuery {
    */
   metrics?: MetricAggregation[];
   /**
+   * List of filters
+   */
+  filters?: QueryFilter[];
+  /**
    * Lucene query
    */
   query?: string;
@@ -405,4 +416,5 @@ export interface Elasticsearch extends DataQuery {
 export const defaultElasticsearch: Partial<Elasticsearch> = {
   bucketAggs: [],
   metrics: [],
+  filters: [],
 };

--- a/src/datasource/base.ts
+++ b/src/datasource/base.ts
@@ -16,9 +16,9 @@ import {
   TimeRange,
 } from '@grafana/data';
 import { BucketAggregation, DataLinkConfig, ElasticsearchQuery, TermsQuery, FieldCapabilitiesResponse } from '@/types';
-import { 
-  DataSourceWithBackend, 
-  getTemplateSrv, 
+import {
+  DataSourceWithBackend,
+  getTemplateSrv,
   TemplateSrv } from '@grafana/runtime';
 import { QuickwitOptions } from 'quickwit';
 import { getDataQuery } from 'QueryBuilder/elastic';
@@ -28,15 +28,15 @@ import { isMetricAggregationWithField } from 'components/QueryEditor/MetricAggre
 import { bucketAggregationConfig } from 'components/QueryEditor/BucketAggregationsEditor/utils';
 import { isBucketAggregationWithField } from 'components/QueryEditor/BucketAggregationsEditor/aggregations';
 import ElasticsearchLanguageProvider from 'LanguageProvider';
-import { fieldTypeMap } from 'utils';
+import { fieldTypeMap, hasWhiteSpace } from 'utils';
 import { addAddHocFilter } from 'modifyQuery';
 import { getQueryResponseProcessor } from 'datasource/processResponse';
 
 import { SECOND } from 'utils/time';
 import { GConstructor } from 'utils/mixins';
-import { LuceneQuery } from '@/utils/lucene';
-import { uidMaker } from "@/utils/uid" 
+import { newFilterId, uidMaker } from '@/utils/uid';
 import { DefaultsConfigOverrides } from 'store/defaults/conf';
+import { isSet } from '@/utils';
 
 export type BaseQuickwitDataSourceConstructor = GConstructor<BaseQuickwitDataSource>
 
@@ -122,18 +122,39 @@ export class BaseQuickwitDataSource
       return query;
     }
 
-    let lquery = LuceneQuery.parse(query.query ?? '')
-    switch (action.type) {
-      case 'ADD_FILTER': {
-        lquery = lquery.addFilter(action.options.key, action.options.value)
-        break;
+    const operationsMap: Record<string, string> = {
+      'ADD_FILTER': '=',
+      'ADD_FILTER_OUT': '!=',
+    };
+    const operation = operationsMap[action.type];
+
+    if (operation) {
+      // If the user has not added any filter, we can simply modify the last one (which is empty)
+      const len = query.filters?.length ?? 0;
+      if (len > 0) {
+        const last = query.filters![len - 1];
+        if (!isSet(last.filter.key) && !isSet(last.filter.value)) {
+          last.filter.key = action.options.key;
+          last.filter.operator = operation;
+          last.filter.value = action.options.value;
+          return query;
+        }
       }
-      case 'ADD_FILTER_OUT': {
-        lquery = lquery.addFilter(action.options.key, action.options.value, '-')
-        break;
-      }
+
+      query.filters?.push({
+        id: newFilterId(),
+        hide: false,
+        filter: {
+          key: action.options.key,
+          operator: operation,
+          value: action.options.value,
+        },
+      });
+    } else {
+      console.warn('unsupported operation', action.type);
     }
-    return { ...query, query: lquery.toString() };
+
+    return { ...query };
   }
 
   getDataQueryRequest(queryDef: TermsQuery, range: TimeRange, requestId?: string) {
@@ -198,7 +219,7 @@ export class BaseQuickwitDataSource
           .map(field_capability => {
             return {
               text: field_capability.field_name,
-              type: fieldTypeMap[field_capability.type],  
+              type: fieldTypeMap[field_capability.type],
             }
           });
         const uniquefieldCapabilities = fieldCapabilities.filter((field_capability, index, self) =>
@@ -336,14 +357,36 @@ export class BaseQuickwitDataSource
       return bucketAgg;
     };
 
+    const renderedQuery = (() => {
+      let q = this.interpolateLuceneQuery(query.query || '', scopedVars);
+      const queryFilters = query.filters
+        ?.filter((f) => {
+          if (f.hide) {
+            return false;
+          }
+          const hasValidValue = (
+            ['exists', 'not exists'].includes(f.filter.operator) || isSet(f.filter.value)
+          ) && (
+            !['term', 'not term'].includes(f.filter.operator) || !hasWhiteSpace(f.filter.value)
+          )
+
+          return isSet(f.filter.key) && hasValidValue && isSet(f.filter.operator)
+        })
+        .map((f) => f.filter);
+      q = this.addAdHocFilters(q, queryFilters)
+      q = this.addAdHocFilters(q, filters)
+      return q
+    })()
+
     const expandedQuery = {
       ...query,
       datasource: this.getRef(),
-      query: this.addAdHocFilters(this.interpolateLuceneQuery(query.query || '', scopedVars), filters),
+      query: renderedQuery,
       bucketAggs: query.bucketAggs?.map(interpolateBucketAgg),
     };
 
     const finalQuery = JSON.parse(this.templateSrv.replace(JSON.stringify(expandedQuery), scopedVars));
+    console.log('Final query', finalQuery.query)
     return finalQuery;
   }
 

--- a/src/datasource/base.ts
+++ b/src/datasource/base.ts
@@ -3,6 +3,7 @@ import { Observable, lastValueFrom, from, of, map, mergeMap } from 'rxjs';
 import {
   AbstractQuery,
   AdHocVariableFilter,
+  AppEvents,
   CoreApp,
   DataFrame,
   DataQueryRequest,
@@ -14,10 +15,12 @@ import {
   QueryFixAction,
   ScopedVars,
   TimeRange,
+  ToggleFilterAction,
 } from '@grafana/data';
 import { BucketAggregation, DataLinkConfig, ElasticsearchQuery, TermsQuery, FieldCapabilitiesResponse } from '@/types';
 import {
   DataSourceWithBackend,
+  getAppEvents,
   getTemplateSrv,
   TemplateSrv } from '@grafana/runtime';
 import { QuickwitOptions } from 'quickwit';
@@ -63,6 +66,18 @@ export class BaseQuickwitDataSource
     defaults?: DefaultsConfigOverrides
   };
   languageProvider: ElasticsearchLanguageProvider;
+  // Populated lazily by getFields(). Used by modifyQuery to pick an operator
+  // that's safe for the field's type (phrase queries require positions indexed,
+  // which Quickwit text fields don't have by default).
+  private fieldTypes: Record<string, string> = {};
+  // Tracks (key|value|operator) triples we've already warned about on this
+  // datasource instance so the same filter doesn't spam a toast on every
+  // dashboard re-render.
+  private warnedAdHocFilters: Set<string> = new Set();
+
+  getFieldType(name: string): string | undefined {
+    return this.fieldTypes[name];
+  }
 
 
   constructor(
@@ -79,6 +94,12 @@ export class BaseQuickwitDataSource
     this.queryEditorConfig = settingsData.queryEditorConfig || {};
     this.languageProvider = new ElasticsearchLanguageProvider(this);
     this.annotations = {};
+
+    // Warm the schema cache so modifyQuery can pick the right operator even when
+    // the query editor hasn't mounted (e.g. dashboard view mode). Fire-and-forget.
+    if (this.index) {
+      lastValueFrom(this.getFields()).catch(() => {});
+    }
   }
 
   query(request: DataQueryRequest<ElasticsearchQuery>): Observable<DataQueryResponse> {
@@ -121,38 +142,84 @@ export class BaseQuickwitDataSource
     if (!action.options) {
       return query;
     }
-
-    const operationsMap: Record<string, string> = {
-      'ADD_FILTER': '=',
-      'ADD_FILTER_OUT': '!=',
-    };
-    const operation = operationsMap[action.type];
-
-    if (operation) {
-      // If the user has not added any filter, we can simply modify the last one (which is empty)
-      const len = query.filters?.length ?? 0;
-      if (len > 0) {
-        const last = query.filters![len - 1];
-        if (!isSet(last.filter.key) && !isSet(last.filter.value)) {
-          last.filter.key = action.options.key;
-          last.filter.operator = operation;
-          last.filter.value = action.options.value;
-          return query;
-        }
-      }
-
-      query.filters?.push({
-        id: newFilterId(),
-        hide: false,
-        filter: {
-          key: action.options.key,
-          operator: operation,
-          value: action.options.value,
-        },
-      });
-    } else {
+    if (action.type !== 'ADD_FILTER' && action.type !== 'ADD_FILTER_OUT') {
       console.warn('unsupported operation', action.type);
+      return query;
     }
+
+    const key = action.options.key;
+    const rawValue = String(action.options.value ?? '');
+    const negate = action.type === 'ADD_FILTER_OUT';
+    return this.addFilterToQuery(query, key, rawValue, negate);
+  }
+
+  /**
+   * Newer Grafana interface (DataSourceWithToggleableQueryFiltersSupport) used
+   * by the Logs panel in dashboards. Preferred over modifyQuery when present.
+   */
+  toggleQueryFilter(query: ElasticsearchQuery, filter: ToggleFilterAction): ElasticsearchQuery {
+    const key = filter.options.key;
+    const rawValue = String(filter.options.value ?? '');
+    const negate = filter.type === 'FILTER_OUT';
+
+    // If the same (key, value) filter is already present, toggle it off.
+    const existingIdx = (query.filters ?? []).findIndex(
+      (f) => f.filter.key === key && f.filter.value === rawValue
+    );
+    if (existingIdx !== -1) {
+      const next = [...(query.filters ?? [])];
+      next.splice(existingIdx, 1);
+      return { ...query, filters: next.length ? next : [{ id: newFilterId(), filter: { key: '', operator: '=', value: '' } }] };
+    }
+    return this.addFilterToQuery(query, key, rawValue, negate);
+  }
+
+  queryHasFilter(query: ElasticsearchQuery, filter: { key: string; value: string }): boolean {
+    return (query.filters ?? []).some(
+      (f) => f.filter.key === filter.key && f.filter.value === filter.value && !f.hide
+    );
+  }
+
+  private addFilterToQuery(query: ElasticsearchQuery, key: string, rawValue: string, negate: boolean): ElasticsearchQuery {
+    const fieldType = this.fieldTypes[key];
+    const isText = fieldType === 'text';
+
+    // Text field + value with whitespace: no single filter can represent this.
+    // Quickwit text fields lack positions so phrase fails, and `term` can't
+    // express whitespace. Warn the user and abort rather than add a broken or
+    // approximate filter.
+    if (isText && hasWhiteSpace(rawValue)) {
+      getAppEvents().publish({
+        type: AppEvents.alertWarning.name,
+        payload: [
+          `Cannot filter on "${key}"`,
+          `Quickwit text fields don't index positions by default, so "${rawValue}" can't be filtered as a phrase. Add this filter manually or edit the Lucene query.`,
+        ],
+      });
+      return query;
+    }
+
+    const value = rawValue;
+    const operator = isText && value !== ''
+      ? (negate ? 'not term' : 'term')
+      : (negate ? '!=' : '=');
+
+    // If the user hasn't populated any filter yet, reuse the trailing empty one.
+    const len = query.filters?.length ?? 0;
+    if (len > 0) {
+      const last = query.filters![len - 1];
+      if (!isSet(last.filter.key) && !isSet(last.filter.value)) {
+        last.filter.key = key;
+        last.filter.operator = operator;
+        last.filter.value = value;
+        return query;
+      }
+    }
+    query.filters?.push({
+      id: newFilterId(),
+      hide: false,
+      filter: { key, operator, value },
+    });
 
     return { ...query };
   }
@@ -195,6 +262,18 @@ export class BaseQuickwitDataSource
       end_timestamp: Math.ceil(range.to.valueOf()/SECOND),
     })).pipe(
       map((field_capabilities_response: FieldCapabilitiesResponse) => {
+        // Cache field → type on the datasource for modifyQuery to consult.
+        // Quickwit routes phrase queries to the text variant first on multi-indexed
+        // fields (text+keyword), and text fields don't index positions by default.
+        // So prefer 'text' when present — it drives safer operator choices downstream.
+        for (const [name, caps] of Object.entries(field_capabilities_response.fields)) {
+          const typeKeys = Object.keys(caps);
+          const chosen = typeKeys.includes('text') ? 'text' : typeKeys[0];
+          if (chosen) {
+            this.fieldTypes[name] = chosen;
+          }
+        }
+
         const shouldAddField = (field: any) => {
           if (spec.aggregatable !== undefined && field.aggregatable !== spec.aggregatable) {
             return false
@@ -386,7 +465,6 @@ export class BaseQuickwitDataSource
     };
 
     const finalQuery = JSON.parse(this.templateSrv.replace(JSON.stringify(expandedQuery), scopedVars));
-    console.log('Final query', finalQuery.query)
     return finalQuery;
   }
 
@@ -396,7 +474,42 @@ export class BaseQuickwitDataSource
     }
     let finalQuery = query;
     adhocFilters.forEach((filter) => {
-      finalQuery = addAddHocFilter(finalQuery, filter);
+      const fieldType = this.fieldTypes[filter.key];
+      const isText = fieldType === 'text';
+      const value = filter.value ?? '';
+
+      // Text field + whitespace value + phrase operator would emit a phrase query,
+      // which fails on Quickwit text fields without positions indexed. Skip the
+      // filter — better a no-op than a broken panel. Fire a toast once per
+      // (key|value|operator) so the user knows why it's not applying, without
+      // spamming on every dashboard render.
+      if (isText && hasWhiteSpace(value) && (filter.operator === '=' || filter.operator === '!=')) {
+        const dedupKey = `${filter.key}|${value}|${filter.operator}`;
+        if (!this.warnedAdHocFilters.has(dedupKey)) {
+          this.warnedAdHocFilters.add(dedupKey);
+          getAppEvents().publish({
+            type: AppEvents.alertWarning.name,
+            payload: [
+              `Filter on "${filter.key}" was skipped`,
+              `Quickwit text fields don't index positions by default, so "${value}" can't be filtered as a phrase. Edit the Lucene query directly for this case.`,
+            ],
+          });
+        }
+        return;
+      }
+
+      // For text fields with single-token values, upgrade '=' to 'term' (and
+      // '!=' to 'not term') so the emitted query doesn't require positions.
+      let effective = filter;
+      if (isText && !hasWhiteSpace(value)) {
+        if (filter.operator === '=') {
+          effective = { ...filter, operator: 'term' };
+        } else if (filter.operator === '!=') {
+          effective = { ...filter, operator: 'not term' };
+        }
+      }
+
+      finalQuery = addAddHocFilter(finalQuery, effective);
     });
 
     return finalQuery;

--- a/src/datasource/supplementaryQueries.ts
+++ b/src/datasource/supplementaryQueries.ts
@@ -102,6 +102,7 @@ export function withSupplementaryQueries<T extends BaseQuickwitDataSourceConstru
           query: query.query,
           metrics: [{ type: 'count', id: '1' }],
           bucketAggs,
+          filters: query.filters,
         };
 
       default:

--- a/src/hooks/useFields.test.tsx
+++ b/src/hooks/useFields.test.tsx
@@ -23,6 +23,7 @@ describe('useFields hook', () => {
       query: '',
       metrics: [defaultMetricAgg()],
       bucketAggs: [defaultBucketAgg()],
+      filters: []
     };
 
     const getFields: ElasticDatasource['getFields'] = jest.fn(() => from([[]]));

--- a/src/hooks/useNextId.test.tsx
+++ b/src/hooks/useNextId.test.tsx
@@ -16,6 +16,7 @@ describe('useNextId', () => {
       query: '',
       metrics: [{ id: '1', type: 'avg' }],
       bucketAggs: [{ id: '2', type: 'date_histogram' }],
+      filters: [],
     };
     const wrapper = ({ children }: PropsWithChildren<{}>) => {
       return (

--- a/src/modifyQuery.ts
+++ b/src/modifyQuery.ts
@@ -5,7 +5,8 @@ import { AdHocVariableFilter } from '@grafana/data';
  * Adds a label:"value" expression to the query.
  */
 export function addAddHocFilter(query: string, filter: AdHocVariableFilter): string {
-  if (!filter.key || !filter.value) {
+  const hasValidValue = ['exists', 'not exists'].includes(filter.operator) || !!filter.value
+  if (!filter.key || !hasValidValue) {
     return query;
   }
 
@@ -38,6 +39,18 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
       break;
     case '<':
       addHocFilter = `${key}:<${value}`;
+      break;
+    case 'term':
+      addHocFilter = `${key}:${value}`;
+      break;
+    case 'not term':
+      addHocFilter = `-${key}:${value}`;
+      break;
+    case 'exists':
+      addHocFilter = `${key}:*`;
+      break;
+    case 'not exists':
+      addHocFilter = `-${key}:*`;
       break;
   }
   return concatenate(query, addHocFilter,'AND');

--- a/src/queryDef.ts
+++ b/src/queryDef.ts
@@ -6,7 +6,9 @@ import {
   MovingAverageModelOption,
   MetricAggregationType,
   DateHistogram,
+  QueryFilter,
 } from './types';
+import { newFilterId } from '@/utils/uid';
 
 export const extendedStats: ExtendedStat[] = [
   { label: 'Avg', value: 'avg' },
@@ -33,6 +35,19 @@ export function defaultMetricAgg(id = '1'): MetricAggregation {
 
 export function defaultBucketAgg(id = '1'): DateHistogram {
   return { type: 'date_histogram', id, settings: { interval: 'auto' } };
+}
+
+export const filterOperations = [
+  { label: 'phrase', value: '=' },
+  { label: 'not phrase', value: '!=' },
+  { label: 'term', value: 'term' },
+  { label: 'not term', value: 'not term' },
+  { label: 'exists', value: 'exists' },
+  { label: 'not exists', value: 'not exists' },
+];
+
+export function defaultFilter(id = newFilterId()): QueryFilter {
+  return { id, filter: { key: '', operator: filterOperations[0].value, value: '' } };
 }
 
 export const findMetricById = (metrics: MetricAggregation[], id: MetricAggregation['id']) =>

--- a/src/queryDef.ts
+++ b/src/queryDef.ts
@@ -37,14 +37,48 @@ export function defaultBucketAgg(id = '1'): DateHistogram {
   return { type: 'date_histogram', id, settings: { interval: 'auto' } };
 }
 
-export const filterOperations = [
-  { label: 'phrase', value: '=' },
-  { label: 'not phrase', value: '!=' },
-  { label: 'term', value: 'term' },
-  { label: 'not term', value: 'not term' },
+export type FilterFieldCategory = 'text' | 'keyword' | 'number' | 'date' | 'boolean' | 'other';
+
+export interface FilterOperation {
+  label: string;
+  value: string;
+  // Field categories this operation applies to. Undefined = always available.
+  types?: FilterFieldCategory[];
+}
+
+export const filterOperations: FilterOperation[] = [
+  { label: 'is', value: '=' },
+  { label: 'is not', value: '!=' },
+  { label: 'contains', value: 'term', types: ['text'] },
+  { label: 'does not contain', value: 'not term', types: ['text'] },
+  { label: '>', value: '>', types: ['number', 'date'] },
+  { label: '<', value: '<', types: ['number', 'date'] },
   { label: 'exists', value: 'exists' },
-  { label: 'not exists', value: 'not exists' },
+  { label: 'does not exist', value: 'not exists' },
 ];
+
+/**
+ * Map a Quickwit/Elasticsearch raw field type (as returned by _field_caps) to
+ * a coarser category used to decide which operators to expose in the filter UI.
+ */
+export function categorizeFieldType(rawType?: string): FilterFieldCategory {
+  if (!rawType) {return 'other';}
+  if (rawType === 'text') {return 'text';}
+  if (rawType === 'keyword') {return 'keyword';}
+  if (['long', 'integer', 'int', 'short', 'byte', 'double', 'float', 'scaled_float', 'half_float', 'unsigned_long'].includes(rawType)) {return 'number';}
+  if (['date', 'date_nanos'].includes(rawType)) {return 'date';}
+  if (rawType === 'boolean' || rawType === 'bool') {return 'boolean';}
+  return 'other';
+}
+
+/**
+ * Operations available for a given field category. When the category is 'other'
+ * (unknown field) we return everything so the user still has full control.
+ */
+export function filterOperationsFor(category: FilterFieldCategory): FilterOperation[] {
+  if (category === 'other') {return filterOperations;}
+  return filterOperations.filter((op) => !op.types || op.types.includes(category));
+}
 
 export function defaultFilter(id = newFilterId()): QueryFilter {
   return { id, filter: { key: '', operator: filterOperations[0].value, value: '' } };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -131,3 +131,8 @@ export const fieldTypeMap: Record<string, string> = {
   float: 'number',
   scaled_float: 'number'
 };
+
+export const isSet = (v: string) => v !== '' && v !== undefined && v !== null;
+
+export const hasWhiteSpace = (s: string) => /\s/g.test(s);
+

--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -1,3 +1,5 @@
+import { QueryFilter } from '@/dataquery.gen';
+
 export function uidMaker(prefix: string){
   let i = 1;
   return {
@@ -9,4 +11,8 @@ export function uidMaker(prefix: string){
       i=1;
     }
   }
+}
+
+export function newFilterId(): QueryFilter['id'] {
+  return Math.floor(Math.random() * 100_000_000).toString()
 }


### PR DESCRIPTION
This is based on @ross-paypay work in #160, I added some autocomplete on the value, renamed the filter (is/contains/exists), with a tooltip for some info, and added a warning toast for filtering on whitespace when field is not indexed. 

<img width="996" height="321" alt="image" src="https://github.com/user-attachments/assets/14e24ab5-a9f8-4422-b4e3-64d916fe44ee" />
<img width="1254" height="564" alt="image" src="https://github.com/user-attachments/assets/32dd17ab-e878-41ae-aa31-10885fd6c3af" />

cc @ranger-ross FYI :smile: 