### PR TITLE
Show useful log message by default for OTEL logs

### DIFF
--- a/src/datasource/processResponse.test.ts
+++ b/src/datasource/processResponse.test.ts
@@ -22,7 +22,7 @@ function makeDatasource(overrides: { logMessageField?: string; dataLinks?: any[]
 
 describe('processLogsDataFrame', () => {
   describe('with logMessageField configured', () => {
-    it('inserts synthetic $qw_message field from configured field', () => {
+    it('uses configured field value', () => {
       const ds = makeDatasource({ logMessageField: 'line' });
       const df = makeDataFrame([
         makeField('timestamp', FieldType.time, [1000, 2000]),
@@ -32,7 +32,6 @@ describe('processLogsDataFrame', () => {
 
       processLogsDataFrame(ds, df);
 
-      expect(df.fields[0].name).toBe('timestamp');
       expect(df.fields[1].name).toBe('$qw_message');
       expect(df.fields[1].values).toEqual(['hello world', 'goodbye world']);
     });
@@ -52,35 +51,139 @@ describe('processLogsDataFrame', () => {
       expect(df.fields[1].values[0]).toBe('method=GET path=/blog status=200');
     });
 
-    it('inserts empty $qw_message when configured field does not exist', () => {
+    it('falls back when configured field does not exist', () => {
       const ds = makeDatasource({ logMessageField: 'nonexistent' });
       const df = makeDataFrame([
         makeField('timestamp', FieldType.time, [1000]),
-        makeField('line', FieldType.string, ['hello']),
+        makeField('body.message', FieldType.string, ['the real message']),
       ]);
 
       processLogsDataFrame(ds, df);
 
-      // $qw_message is still inserted but with empty values
       expect(df.fields[1].name).toBe('$qw_message');
-      expect(df.fields[1].values[0]).toBe('');
+      expect(df.fields[1].values[0]).toBe('the real message');
+    });
+
+    it('falls back when configured field value is empty for a row', () => {
+      const ds = makeDatasource({ logMessageField: 'line' });
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000, 2000]),
+        makeField('line', FieldType.string, ['has content', '']),
+        makeField('body.message', FieldType.string, ['', 'fallback message']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('has content');
+      expect(df.fields[1].values[1]).toBe('fallback message');
     });
   });
 
-  describe('without logMessageField configured', () => {
-    it('does not insert any synthetic field', () => {
+  describe('OTEL fallback (no logMessageField)', () => {
+    it('picks body.message when present', () => {
+      const ds = makeDatasource();
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000]),
+        makeField('body.message', FieldType.string, ['GET /assets/app.js HTTP/1.1 200']),
+        makeField('body.stream', FieldType.string, ['stdout']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('GET /assets/app.js HTTP/1.1 200');
+    });
+
+    it('picks attributes.message when body.message is absent', () => {
+      const ds = makeDatasource();
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000]),
+        makeField('attributes.message', FieldType.string, ['SSO user already exists']),
+        makeField('attributes.severity', FieldType.string, ['INFO']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('SSO user already exists');
+    });
+
+    it('prefers body.message over attributes.message', () => {
+      const ds = makeDatasource();
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000]),
+        makeField('body.message', FieldType.string, ['from body']),
+        makeField('attributes.message', FieldType.string, ['from attributes']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('from body');
+    });
+
+    it('builds key=value summary when no well-known fields exist', () => {
+      const ds = makeDatasource();
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000]),
+        makeField('attributes.method', FieldType.string, ['GET']),
+        makeField('attributes.path', FieldType.string, ['/blog']),
+        makeField('attributes.status', FieldType.number, [200]),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('method=GET path=/blog status=200');
+    });
+
+    it('strips attributes. prefix in key=value summary', () => {
       const ds = makeDatasource();
       const df = makeDataFrame([
         makeField('timestamp', FieldType.time, [1000]),
         makeField('attributes.controller', FieldType.string, ['BlogController']),
-        makeField('attributes.method', FieldType.string, ['GET']),
       ]);
 
       processLogsDataFrame(ds, df);
 
-      // No $qw_message field — current behavior is to do nothing
-      const fieldNames = df.fields.map((f) => f.name);
-      expect(fieldNames).not.toContain('$qw_message');
+      expect(df.fields[1].values[0]).toBe('controller=BlogController');
+    });
+
+    it('skips metadata fields in key=value summary', () => {
+      const ds = makeDatasource();
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000]),
+        makeField('attributes.method', FieldType.string, ['GET']),
+        makeField('attributes.pod_name', FieldType.string, ['rx-production-abc123']),
+        makeField('attributes.node_labels.arch', FieldType.string, ['amd64']),
+        makeField('sort', FieldType.other, [[1684398201000]]),
+        makeField('severity_text', FieldType.string, ['INFO']),
+        makeField('body.stream', FieldType.string, ['stdout']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('method=GET');
+    });
+
+    it('handles mixed log types per row', () => {
+      const ds = makeDatasource();
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000, 2000, 3000]),
+        makeField('attributes.message', FieldType.string, ['SSO login', '', '']),
+        makeField('attributes.method', FieldType.string, ['', 'GET', '']),
+        makeField('attributes.path', FieldType.string, ['', '/blog', '']),
+        makeField('body.message', FieldType.string, ['', '', 'raw nginx log line']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('SSO login');
+      expect(df.fields[1].values[1]).toBe('method=GET path=/blog');
+      expect(df.fields[1].values[2]).toBe('raw nginx log line');
     });
   });
 
@@ -106,7 +209,6 @@ describe('processLogsDataFrame', () => {
 
       processLogsDataFrame(ds, df);
 
-      // Should not have inserted $qw_message
       const fieldNames = df.fields.map((f) => f.name);
       expect(fieldNames).not.toContain('$qw_message');
     });

--- a/src/datasource/processResponse.test.ts
+++ b/src/datasource/processResponse.test.ts
@@ -1,0 +1,131 @@
+import { DataFrame, Field, FieldType } from '@grafana/data';
+import { processLogsDataFrame } from './processResponse';
+
+function makeField(name: string, type: FieldType, values: any[]): Field {
+  return { name, type, config: {}, values };
+}
+
+function makeDataFrame(fields: Field[], refId = 'A'): DataFrame {
+  return {
+    refId,
+    fields,
+    length: fields[0]?.values.length ?? 0,
+  };
+}
+
+function makeDatasource(overrides: { logMessageField?: string; dataLinks?: any[] } = {}) {
+  return {
+    logMessageField: overrides.logMessageField ?? '',
+    dataLinks: overrides.dataLinks ?? [],
+  } as any;
+}
+
+describe('processLogsDataFrame', () => {
+  describe('with logMessageField configured', () => {
+    it('inserts synthetic $qw_message field from configured field', () => {
+      const ds = makeDatasource({ logMessageField: 'line' });
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000, 2000]),
+        makeField('line', FieldType.string, ['hello world', 'goodbye world']),
+        makeField('level', FieldType.string, ['info', 'error']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[0].name).toBe('timestamp');
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values).toEqual(['hello world', 'goodbye world']);
+    });
+
+    it('joins multiple configured fields with key=value format', () => {
+      const ds = makeDatasource({ logMessageField: 'method,path,status' });
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000]),
+        makeField('method', FieldType.string, ['GET']),
+        makeField('path', FieldType.string, ['/blog']),
+        makeField('status', FieldType.string, ['200']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('method=GET path=/blog status=200');
+    });
+
+    it('inserts empty $qw_message when configured field does not exist', () => {
+      const ds = makeDatasource({ logMessageField: 'nonexistent' });
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000]),
+        makeField('line', FieldType.string, ['hello']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      // $qw_message is still inserted but with empty values
+      expect(df.fields[1].name).toBe('$qw_message');
+      expect(df.fields[1].values[0]).toBe('');
+    });
+  });
+
+  describe('without logMessageField configured', () => {
+    it('does not insert any synthetic field', () => {
+      const ds = makeDatasource();
+      const df = makeDataFrame([
+        makeField('timestamp', FieldType.time, [1000]),
+        makeField('attributes.controller', FieldType.string, ['BlogController']),
+        makeField('attributes.method', FieldType.string, ['GET']),
+      ]);
+
+      processLogsDataFrame(ds, df);
+
+      // No $qw_message field — current behavior is to do nothing
+      const fieldNames = df.fields.map((f) => f.name);
+      expect(fieldNames).not.toContain('$qw_message');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('skips empty dataframes', () => {
+      const ds = makeDatasource({ logMessageField: 'line' });
+      const df = makeDataFrame([]);
+
+      processLogsDataFrame(ds, df);
+
+      expect(df.fields.length).toBe(0);
+    });
+
+    it('skips log-volume dataframes', () => {
+      const ds = makeDatasource({ logMessageField: 'line' });
+      const df = makeDataFrame(
+        [
+          makeField('timestamp', FieldType.time, [1000]),
+          makeField('line', FieldType.string, ['hello']),
+        ],
+        'log-volume-A'
+      );
+
+      processLogsDataFrame(ds, df);
+
+      // Should not have inserted $qw_message
+      const fieldNames = df.fields.map((f) => f.name);
+      expect(fieldNames).not.toContain('$qw_message');
+    });
+
+    it('skips dataframes with no refId', () => {
+      const ds = makeDatasource({ logMessageField: 'line' });
+      const df: DataFrame = {
+        refId: undefined,
+        fields: [
+          makeField('timestamp', FieldType.time, [1000]),
+          makeField('line', FieldType.string, ['hello']),
+        ],
+        length: 1,
+      };
+
+      processLogsDataFrame(ds, df);
+
+      const fieldNames = df.fields.map((f) => f.name);
+      expect(fieldNames).not.toContain('$qw_message');
+    });
+  });
+});

--- a/src/datasource/processResponse.ts
+++ b/src/datasource/processResponse.ts
@@ -17,6 +17,58 @@ export function getQueryResponseProcessor(datasource: BaseQuickwitDataSource, re
   };
 }
 function getCustomFieldName(fieldname: string) { return `$qw_${fieldname}`; }
+
+const OTEL_MESSAGE_FIELDS = ['body.message', 'attributes.message'];
+
+const SKIP_FIELD_PREFIXES = [
+  'attributes.pod_', 'attributes.node_labels.', 'attributes.namespace_labels.',
+  'attributes.container_image', 'attributes.pod_owner',
+];
+const SKIP_FIELD_NAMES = new Set([
+  'sort', 'severity_text', 'body.stream',
+]);
+
+function isMetadataField(name: string, timeField: string): boolean {
+  if (name === timeField || SKIP_FIELD_NAMES.has(name)) {
+    return true;
+  }
+  return SKIP_FIELD_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+function stripPrefix(name: string): string {
+  if (name.startsWith('attributes.')) {
+    return name.slice('attributes.'.length);
+  }
+  if (name.startsWith('body.')) {
+    return name.slice('body.'.length);
+  }
+  return name;
+}
+
+function buildFallbackMessage(dataFrame: DataFrame, rowIdx: number, timeFieldName: string): string {
+  for (const candidate of OTEL_MESSAGE_FIELDS) {
+    const field = dataFrame.fields.find((f) => f.name === candidate);
+    if (field) {
+      const val = field.values[rowIdx];
+      if (val != null && val !== '') {
+        return String(val);
+      }
+    }
+  }
+
+  const parts: string[] = [];
+  for (const field of dataFrame.fields) {
+    if (isMetadataField(field.name, timeFieldName) || field.type === FieldType.time) {
+      continue;
+    }
+    const val = field.values[rowIdx];
+    if (val != null && val !== '') {
+      parts.push(`${stripPrefix(field.name)}=${val}`);
+    }
+  }
+  return parts.join(' ');
+}
+
 export function processLogsDataFrame(datasource: BaseQuickwitDataSource, dataFrame: DataFrame) {
   // Ignore log volume dataframe, no need to add links or a displayed message field.
   if (!dataFrame.refId || dataFrame.refId.startsWith('log-volume')) {
@@ -26,38 +78,46 @@ export function processLogsDataFrame(datasource: BaseQuickwitDataSource, dataFra
   if (dataFrame.length===0 || dataFrame.fields.length === 0) {
     return;
   }
-  if (datasource.logMessageField) {
-    const messageFields = datasource.logMessageField.split(',');
-    let field_idx_list = [];
-    for (const messageField of messageFields) {
-      const field_idx = dataFrame.fields.findIndex((field) => field.name === messageField);
-      if (field_idx !== -1) {
-        field_idx_list.push(field_idx);
-      }
+
+  const configuredFields = datasource.logMessageField ? datasource.logMessageField.split(',') : [];
+  const field_idx_list: number[] = [];
+  for (const messageField of configuredFields) {
+    const field_idx = dataFrame.fields.findIndex((field) => field.name === messageField);
+    if (field_idx !== -1) {
+      field_idx_list.push(field_idx);
     }
-    const displayedMessages = Array(dataFrame.length);
-    for (let idx = 0; idx < dataFrame.length; idx++) {
-      let displayedMessage = "";
-      // If we have only one field, we assume the field name is obvious for the user and we don't need to show it.
-      if (field_idx_list.length === 1) {
-        displayedMessage = `${dataFrame.fields[field_idx_list[0]].values[idx]}`;
-      } else {
-        for (const field_idx of field_idx_list) {
-          displayedMessage += ` ${dataFrame.fields[field_idx].name}=${dataFrame.fields[field_idx].values[idx]}`;
-        }
+  }
+
+  const timeFieldName = dataFrame.fields.find((f) => f.type === FieldType.time)?.name ?? '';
+  const displayedMessages = Array(dataFrame.length);
+
+  for (let idx = 0; idx < dataFrame.length; idx++) {
+    let displayedMessage = "";
+
+    if (field_idx_list.length === 1) {
+      displayedMessage = `${dataFrame.fields[field_idx_list[0]].values[idx] ?? ''}`;
+    } else if (field_idx_list.length > 1) {
+      for (const field_idx of field_idx_list) {
+        displayedMessage += ` ${dataFrame.fields[field_idx].name}=${dataFrame.fields[field_idx].values[idx]}`;
       }
-      displayedMessages[idx] = displayedMessage.trim();
+      displayedMessage = displayedMessage.trim();
     }
 
-    const newField: Field = {
-      name: getCustomFieldName('message'),
-      type: FieldType.string,
-      config: {},
-      values: displayedMessages,
-    };
-    const [timestamp, ...rest] = dataFrame.fields;
-    dataFrame.fields = [timestamp, newField, ...rest];
+    if (!displayedMessage) {
+      displayedMessage = buildFallbackMessage(dataFrame, idx, timeFieldName);
+    }
+
+    displayedMessages[idx] = displayedMessage;
   }
+
+  const newField: Field = {
+    name: getCustomFieldName('message'),
+    type: FieldType.string,
+    config: {},
+    values: displayedMessages,
+  };
+  const [timestamp, ...rest] = dataFrame.fields;
+  dataFrame.fields = [timestamp, newField, ...rest];
 
   if (!datasource.dataLinks.length) {
     return;


### PR DESCRIPTION
## Summary

```
Without organize transform:
  timestamp → $qw_message → everything else
  Grafana picks $qw_message ✓

With your organize transform:
  timestamp → body.message → $qw_message → everything else
  Grafana picks body.message
  body.message is empty for lograge logs → blank line ✗
  body.message is empty for custom logger logs → blank line ✗
```

- When `logMessageField` is unconfigured or its value is empty, the Logs panel shows blank lines forcing users to expand every entry
- Adds a per-row fallback that tries well-known OTEL fields (`body.message`, `attributes.message`) then builds a `key=value` summary from document fields
- Metadata fields (pod info, node labels, sort, etc.) are excluded from the summary and `attributes.` prefixes are stripped for readability
- Mixed log types in the same query (structured logger output, request logs, raw access logs) each show the best available content
- Backwards compatible: users with a working `logMessageField` config see no change

## Test plan
- [x] 14 unit tests covering configured field, OTEL fallback, key=value summary, metadata skipping, mixed log types, and edge cases
- [ ] Manual test: Grafana Explore with OTEL log index and no `logMessageField` configured

Refs #165