### PR TITLE
fix: quick filters QoL  

### DIFF
--- a/src/components/QueryEditor/FilterEditor/index.test.tsx
+++ b/src/components/QueryEditor/FilterEditor/index.test.tsx
@@ -1,0 +1,50 @@
+import { QueryFilter } from '@/types';
+
+import { getPreviousAdHocFilters } from './index';
+
+describe('FilterEditor helpers', () => {
+  it('returns only complete filters before the current filter', () => {
+    const filters: QueryFilter[] = [
+      {
+        id: 'first',
+        filter: { key: 'service', operator: '=', value: 'frontend' },
+      },
+      {
+        id: 'hidden',
+        hide: true,
+        filter: { key: 'cluster', operator: '=', value: 'prod' },
+      },
+      {
+        id: 'incomplete',
+        filter: { key: 'namespace', operator: '=', value: '' },
+      },
+      {
+        id: 'current',
+        filter: { key: 'attributes.grpc_message', operator: '=', value: '' },
+      },
+      {
+        id: 'later',
+        filter: { key: 'status', operator: '=', value: '500' },
+      },
+    ];
+
+    expect(getPreviousAdHocFilters(filters, 'current')).toEqual([
+      { key: 'service', operator: '=', value: 'frontend' },
+    ]);
+  });
+
+  it('does not include previous term filters with whitespace values', () => {
+    const filters: QueryFilter[] = [
+      {
+        id: 'invalid-term',
+        filter: { key: 'message', operator: 'term', value: 'invalid token' },
+      },
+      {
+        id: 'current',
+        filter: { key: 'status', operator: '=', value: '' },
+      },
+    ];
+
+    expect(getPreviousAdHocFilters(filters, 'current')).toEqual([]);
+  });
+});

--- a/src/components/QueryEditor/FilterEditor/index.tsx
+++ b/src/components/QueryEditor/FilterEditor/index.tsx
@@ -7,7 +7,7 @@ import { QueryEditorRow } from '../QueryEditorRow';
 
 import { QueryFilter } from '@/types';
 import { Icon, InlineSegmentGroup, Segment, SegmentAsync, Tooltip } from '@grafana/ui';
-import { MetricFindValue, SelectableValue } from '@grafana/data';
+import { AdHocVariableFilter, MetricFindValue, SelectableValue } from '@grafana/data';
 import {
   addFilter,
   removeFilter,
@@ -17,10 +17,9 @@ import {
   changeFilterValue,
 } from '@/components/QueryEditor/FilterEditor/state/actions';
 import { segmentStyles } from '@/components/QueryEditor/styles';
-import { useFields } from '@/hooks/useFields';
 import { newFilterId } from '@/utils/uid';
 import { categorizeFieldType, filterOperations, filterOperationsFor } from '@/queryDef';
-import { hasWhiteSpace, isSet } from '@/utils';
+import { fuzzySearchSort, hasWhiteSpace, isSet } from '@/utils';
 
 interface FilterEditorProps {
   onSubmit: () => void;
@@ -46,6 +45,30 @@ function filterErrors(filter: QueryFilter): string[] {
   }
 
   return errors;
+}
+
+function isFilterComplete(filter: QueryFilter): boolean {
+  return !filter.hide && filterErrors(filter).length === 0;
+}
+
+export function getPreviousAdHocFilters(filters: QueryFilter[] | undefined, currentId: QueryFilter['id']): AdHocVariableFilter[] {
+  const currentIndex = filters?.findIndex((filter) => filter.id === currentId) ?? -1;
+  if (!filters || currentIndex <= 0) {
+    return [];
+  }
+
+  return filters
+    .slice(0, currentIndex)
+    .filter(isFilterComplete)
+    .map((filter) => filter.filter);
+}
+
+function toFuzzyOptions(values: MetricFindValue[], query?: string): Array<SelectableValue<string>> {
+  return fuzzySearchSort(
+    values.map((value) => String(value.text)),
+    (text) => text,
+    query
+  ).map((text) => ({ label: text, value: text }));
 }
 
 export const FilterEditor = ({ onSubmit }: FilterEditorProps) => {
@@ -98,21 +121,27 @@ export const FilterEditorRow = ({ value, onSubmit }: FilterEditorRowProps) => {
   const dispatch = useDispatch();
   const datasource = useDatasource();
   const range = useRange();
-  const getFields = useFields('filters', 'startsWith');
+  const { filters } = useQuery();
+  const previousFilters = getPreviousAdHocFilters(filters, value.id);
 
   const fieldCategory = categorizeFieldType(datasource.getFieldType?.(value.filter.key));
   const visibleOperations = filterOperationsFor(fieldCategory);
+
+  const loadFields = async (query?: string): Promise<Array<SelectableValue<string>>> => {
+    const values = await datasource.getTagKeys({ filters: previousFilters, timeRange: range });
+    return toFuzzyOptions(values as MetricFindValue[], query);
+  };
 
   const loadValues = async (query?: string): Promise<Array<SelectableValue<string>>> => {
     if (!isSet(value.filter.key) || !datasource.getTagValues) {
       return [];
     }
-    const values: MetricFindValue[] = await datasource.getTagValues({ key: value.filter.key, timeRange: range });
-    const q = query?.toLowerCase();
-    return values
-      .map((v) => String(v.text))
-      .filter((text) => !q || text.toLowerCase().includes(q))
-      .map((text) => ({ label: text, value: text }));
+    const values: MetricFindValue[] = await datasource.getTagValues({
+      key: value.filter.key,
+      filters: previousFilters,
+      timeRange: range,
+    });
+    return toFuzzyOptions(values, query);
   };
 
   return (
@@ -121,7 +150,7 @@ export const FilterEditorRow = ({ value, onSubmit }: FilterEditorRowProps) => {
         <SegmentAsync
           allowCustomValue={true}
           className={segmentStyles}
-          loadOptions={getFields}
+          loadOptions={loadFields}
           reloadOptionsOnChange={true}
           onChange={(e) => {
             const newKey = e.value ?? '';

--- a/src/datasource/base.test.ts
+++ b/src/datasource/base.test.ts
@@ -1,4 +1,9 @@
-import { formatQuery, luceneEscape } from './base';
+import { AdHocVariableFilter } from '@grafana/data';
+import { from } from 'rxjs';
+
+import { addAddHocFilter } from '../modifyQuery';
+import { ElasticsearchQuery } from '../types';
+import { BaseQuickwitDataSource, formatQuery, luceneEscape } from './base';
 
 describe('BaseQuickwitDataSource', () => {
   describe('luceneEscape', () => {
@@ -170,5 +175,151 @@ describe('BaseQuickwitDataSource', () => {
       expect(result).toBe('IN ["value1" "value2"]');
     });
   });
+  });
+
+  describe('quick filters', () => {
+    const addFilterToQuery = (
+      fieldTypes: Record<string, string>,
+      query: ElasticsearchQuery,
+      key: string,
+      value: string,
+      negate = false
+    ) => {
+      return (BaseQuickwitDataSource.prototype as any).addFilterToQuery.call(
+        { fieldTypes },
+        query,
+        key,
+        value,
+        negate
+      ) as ElasticsearchQuery;
+    };
+
+    const renderAdHocFilters = (
+      fieldTypes: Record<string, string>,
+      filters: AdHocVariableFilter[]
+    ) => {
+      return (BaseQuickwitDataSource.prototype as any).addAdHocFilters.call(
+        { fieldTypes },
+        '',
+        filters
+      ) as string;
+    };
+
+    it('adds text filters with whitespace as phrase filters', () => {
+      const query = { refId: 'A', query: '', metrics: [], bucketAggs: [], filters: [] } as any;
+
+      const updatedQuery = addFilterToQuery(
+        { 'attributes.grpc_message': 'text' },
+        query,
+        'attributes.grpc_message',
+        'Error:[(0) invalid token, ]'
+      );
+
+      expect(updatedQuery.filters?.[0].filter).toEqual({
+        key: 'attributes.grpc_message',
+        operator: '=',
+        value: 'Error:[(0) invalid token, ]',
+      });
+    });
+
+    it('renders text phrase filters with quoted Quickwit syntax', () => {
+      const result = renderAdHocFilters(
+        { 'attributes.grpc_message': 'text' },
+        [{
+          key: 'attributes.grpc_message',
+          operator: '=',
+          value: 'Error:[(0) invalid token, ]',
+        }]
+      );
+
+      expect(result).toBe('attributes.grpc_message:"Error:[(0) invalid token, ]"');
+    });
+
+    it('renders negative text phrase filters with quoted Quickwit syntax', () => {
+      const result = renderAdHocFilters(
+        { 'attributes.grpc_message': 'text' },
+        [{
+          key: 'attributes.grpc_message',
+          operator: '!=',
+          value: 'Error:[(0) invalid token, ]',
+        }]
+      );
+
+      expect(result).toBe('-attributes.grpc_message:"Error:[(0) invalid token, ]"');
+    });
+
+    it('keeps simple-token text filters as term filters', () => {
+      const query = { refId: 'A', query: '', metrics: [], bucketAggs: [], filters: [] } as any;
+
+      const updatedQuery = addFilterToQuery(
+        { 'attributes.grpc_message': 'text' },
+        query,
+        'attributes.grpc_message',
+        'unavailable'
+      );
+
+      expect(updatedQuery.filters?.[0].filter.operator).toBe('term');
+    });
+
+    it('keeps punctuated text filters as phrase filters', () => {
+      const query = { refId: 'A', query: '', metrics: [], bucketAggs: [], filters: [] } as any;
+
+      const updatedQuery = addFilterToQuery(
+        { service_name: 'text' },
+        query,
+        'service_name',
+        'auth-api'
+      );
+
+      expect(updatedQuery.filters?.[0].filter).toEqual({
+        key: 'service_name',
+        operator: '=',
+        value: 'auth-api',
+      });
+    });
+
+    it('renders punctuated text filters with quoted Quickwit syntax', () => {
+      const result = renderAdHocFilters(
+        { service_name: 'text' },
+        [{
+          key: 'service_name',
+          operator: '=',
+          value: 'auth-api',
+        }]
+      );
+
+      expect(result).toBe('service_name:"auth-api"');
+    });
+
+    it('escapes special characters in unquoted term filters', () => {
+      const result = addAddHocFilter('', {
+        key: 'attributes.grpc_message',
+        operator: 'term',
+        value: 'error:foo',
+      });
+
+      expect(result).toBe('attributes.grpc_message:error\\:foo');
+    });
+
+    it('applies prior filters when loading tag values', async () => {
+      const getTerms = jest.fn(() => from([[]]));
+
+      await (BaseQuickwitDataSource.prototype as any).getTagValues.call(
+        {
+          fieldTypes: {},
+          addAdHocFilters: BaseQuickwitDataSource.prototype.addAdHocFilters,
+          getTerms,
+        },
+        {
+          key: 'status',
+          filters: [{ key: 'service', operator: '=', value: 'frontend' }],
+        }
+      );
+
+      expect(getTerms).toHaveBeenCalledWith(
+        { field: 'status', query: 'service:"frontend"' },
+        undefined
+      );
+    });
   });
 });

--- a/src/datasource/base.ts
+++ b/src/datasource/base.ts
@@ -3,7 +3,6 @@ import { Observable, lastValueFrom, from, of, map, mergeMap } from 'rxjs';
 import {
   AbstractQuery,
   AdHocVariableFilter,
-  AppEvents,
   CoreApp,
   DataFrame,
   DataQueryRequest,
@@ -20,7 +19,6 @@ import {
 import { BucketAggregation, DataLinkConfig, ElasticsearchQuery, TermsQuery, FieldCapabilitiesResponse } from '@/types';
 import {
   DataSourceWithBackend,
-  getAppEvents,
   getTemplateSrv,
   TemplateSrv } from '@grafana/runtime';
 import { QuickwitOptions } from 'quickwit';
@@ -31,7 +29,7 @@ import { isMetricAggregationWithField } from 'components/QueryEditor/MetricAggre
 import { bucketAggregationConfig } from 'components/QueryEditor/BucketAggregationsEditor/utils';
 import { isBucketAggregationWithField } from 'components/QueryEditor/BucketAggregationsEditor/aggregations';
 import ElasticsearchLanguageProvider from 'LanguageProvider';
-import { fieldTypeMap, hasWhiteSpace } from 'utils';
+import { fieldTypeMap, hasWhiteSpace, isSimpleToken } from 'utils';
 import { addAddHocFilter } from 'modifyQuery';
 import { getQueryResponseProcessor } from 'datasource/processResponse';
 
@@ -67,13 +65,8 @@ export class BaseQuickwitDataSource
   };
   languageProvider: ElasticsearchLanguageProvider;
   // Populated lazily by getFields(). Used by modifyQuery to pick an operator
-  // that's safe for the field's type (phrase queries require positions indexed,
-  // which Quickwit text fields don't have by default).
+  // that matches text field semantics.
   private fieldTypes: Record<string, string> = {};
-  // Tracks (key|value|operator) triples we've already warned about on this
-  // datasource instance so the same filter doesn't spam a toast on every
-  // dashboard re-render.
-  private warnedAdHocFilters: Set<string> = new Set();
 
   getFieldType(name: string): string | undefined {
     return this.fieldTypes[name];
@@ -184,23 +177,9 @@ export class BaseQuickwitDataSource
     const fieldType = this.fieldTypes[key];
     const isText = fieldType === 'text';
 
-    // Text field + value with whitespace: no single filter can represent this.
-    // Quickwit text fields lack positions so phrase fails, and `term` can't
-    // express whitespace. Warn the user and abort rather than add a broken or
-    // approximate filter.
-    if (isText && hasWhiteSpace(rawValue)) {
-      getAppEvents().publish({
-        type: AppEvents.alertWarning.name,
-        payload: [
-          `Cannot filter on "${key}"`,
-          `Quickwit text fields don't index positions by default, so "${rawValue}" can't be filtered as a phrase. Add this filter manually or edit the Lucene query.`,
-        ],
-      });
-      return query;
-    }
-
     const value = rawValue;
-    const operator = isText && value !== ''
+    const useTermOperator = isText && value !== '' && isSimpleToken(value);
+    const operator = useTermOperator
       ? (negate ? 'not term' : 'term')
       : (negate ? '!=' : '=');
 
@@ -314,7 +293,7 @@ export class BaseQuickwitDataSource
   /**
    * Get tag keys for adhoc filters
    */
-  getTagKeys(options: any) {
+  getTagKeys(options: any = {}) {
     const fields = this.getFields({aggregatable:true, range: options.timeRange})
     return lastValueFrom(fields, {defaultValue:[]});
   }
@@ -323,7 +302,8 @@ export class BaseQuickwitDataSource
    * Get tag values for adhoc filters
    */
   getTagValues(options: any) {
-    const terms = this.getTerms({ field: options.key }, options.timeRange)
+    const query = this.addAdHocFilters('', options.filters);
+    const terms = this.getTerms({ field: options.key, query }, options.timeRange)
     return lastValueFrom(terms, {defaultValue:[]});
   }
 
@@ -478,30 +458,10 @@ export class BaseQuickwitDataSource
       const isText = fieldType === 'text';
       const value = filter.value ?? '';
 
-      // Text field + whitespace value + phrase operator would emit a phrase query,
-      // which fails on Quickwit text fields without positions indexed. Skip the
-      // filter — better a no-op than a broken panel. Fire a toast once per
-      // (key|value|operator) so the user knows why it's not applying, without
-      // spamming on every dashboard render.
-      if (isText && hasWhiteSpace(value) && (filter.operator === '=' || filter.operator === '!=')) {
-        const dedupKey = `${filter.key}|${value}|${filter.operator}`;
-        if (!this.warnedAdHocFilters.has(dedupKey)) {
-          this.warnedAdHocFilters.add(dedupKey);
-          getAppEvents().publish({
-            type: AppEvents.alertWarning.name,
-            payload: [
-              `Filter on "${filter.key}" was skipped`,
-              `Quickwit text fields don't index positions by default, so "${value}" can't be filtered as a phrase. Edit the Lucene query directly for this case.`,
-            ],
-          });
-        }
-        return;
-      }
-
-      // For text fields with single-token values, upgrade '=' to 'term' (and
+      // For text fields with simple token values, upgrade '=' to 'term' (and
       // '!=' to 'not term') so the emitted query doesn't require positions.
       let effective = filter;
-      if (isText && !hasWhiteSpace(value)) {
+      if (isText && isSimpleToken(value)) {
         if (filter.operator === '=') {
           effective = { ...filter, operator: 'term' };
         } else if (filter.operator === '!=') {

--- a/src/hooks/useFields.ts
+++ b/src/hooks/useFields.ts
@@ -6,6 +6,7 @@ import { isBucketAggregationType } from '../components/QueryEditor/BucketAggrega
 import { useDatasource, useRange } from '../components/QueryEditor/ElasticsearchQueryContext';
 import { isMetricAggregationType } from '../components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { MetricAggregationType, BucketAggregationType } from '../types';
+import { fuzzySearchMatch, fuzzySearchSort } from '@/utils';
 
 type AggregationType = BucketAggregationType | MetricAggregationType;
 
@@ -46,7 +47,7 @@ const toSelectableValue = ({ text }: MetricFindValue): SelectableValue<string> =
   value: text,
 });
 
-type MatchType = 'contains' | 'startsWith'
+type MatchType = 'contains' | 'startsWith' | 'fuzzy'
 
 /**
  * Returns a function to query the configured datasource for autocomplete values for the specified aggregation type or data types.
@@ -68,13 +69,18 @@ export const useFields = (type: AggregationType | string[], matchType: MatchType
       rawFields = await lastValueFrom(datasource.getFields({aggregatable:true, type:filter, range:range}));
     }
 
-    return rawFields
+    const fields = rawFields
       .filter(({ text }) => {
         if (q === undefined) {
           return true;
         }
+        if (matchType === 'fuzzy') {
+          return fuzzySearchMatch(text, q);
+        }
         return matchType === 'contains' ? text.includes(q) : text.startsWith(q)
-      })
+      });
+
+    return (matchType === 'fuzzy' ? fuzzySearchSort(fields, ({ text }) => text, q) : fields)
       .map(toSelectableValue);
   };
 };

--- a/src/modifyQuery.ts
+++ b/src/modifyQuery.ts
@@ -26,6 +26,7 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
    */
   const key = escapeFilter(filter.key);
   const value = escapeFilterValue(filter.value);
+  const termValue = escapeFilter(filter.value);
   let addHocFilter = '';
   switch (filter.operator) {
     case '=~':
@@ -41,10 +42,10 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
       addHocFilter = `${key}:<${value}`;
       break;
     case 'term':
-      addHocFilter = `${key}:${value}`;
+      addHocFilter = `${key}:${termValue}`;
       break;
     case 'not term':
-      addHocFilter = `-${key}:${value}`;
+      addHocFilter = `-${key}:${termValue}`;
       break;
     case 'exists':
       addHocFilter = `${key}:*`;

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { extractJsonPayload } from "utils"; 
+import { extractJsonPayload, fuzzySearchMatch, fuzzySearchSort, isSimpleToken } from "utils";
 
 describe('Test utils.extractJsonPayload', () => {
     it('Extract valid JSON', () => {
@@ -17,4 +17,38 @@ describe('Test utils.extractJsonPayload', () => {
         const result = extractJsonPayload('Hey {"foo": "bar"} {"foo2": "bar2"}')
         expect(result).toEqual(null);
     });
+});
+
+describe('fuzzy search helpers', () => {
+  it('matches field names using token abbreviations', () => {
+    expect(fuzzySearchMatch('attributes.grpc_message', 'grpc msg')).toBe(true);
+  });
+
+  it('matches values with missing characters', () => {
+    expect(fuzzySearchMatch('Error invalid token', 'err invld')).toBe(true);
+  });
+
+  it('sorts stronger matches first', () => {
+    const result = fuzzySearchSort(
+      ['body.message', 'attributes.grpc_message', 'attributes.http_status'],
+      (value) => value,
+      'grpc msg'
+    );
+
+    expect(result[0]).toBe('attributes.grpc_message');
+  });
+
+  it('does not match unrelated values', () => {
+    expect(fuzzySearchMatch('attributes.grpc_message', 'status code')).toBe(false);
+  });
+});
+
+describe('isSimpleToken', () => {
+  it('accepts analyzer-friendly bare tokens', () => {
+    expect(isSimpleToken('auth_api_1')).toBe(true);
+  });
+
+  it('rejects punctuated values that should be quoted as phrases', () => {
+    expect(isSimpleToken('auth-api')).toBe(false);
+  });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -136,3 +136,127 @@ export const isSet = (v: string) => v !== '' && v !== undefined && v !== null;
 
 export const hasWhiteSpace = (s: string) => /\s/g.test(s);
 
+export const isSimpleToken = (s: string) => /^[A-Za-z0-9_]+$/.test(s);
+
+const normalizeSearchText = (value: string) => value.toLowerCase();
+
+const searchTokens = (value: string) =>
+  normalizeSearchText(value)
+    .split(/[^a-z0-9]+/g)
+    .filter(Boolean);
+
+const isSubsequence = (needle: string, haystack: string) => {
+  let needleIndex = 0;
+  for (let haystackIndex = 0; haystackIndex < haystack.length && needleIndex < needle.length; haystackIndex++) {
+    if (needle[needleIndex] === haystack[haystackIndex]) {
+      needleIndex++;
+    }
+  }
+  return needleIndex === needle.length;
+};
+
+const levenshteinDistance = (a: string, b: string, maxDistance: number) => {
+  if (Math.abs(a.length - b.length) > maxDistance) {
+    return maxDistance + 1;
+  }
+
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  for (let i = 1; i <= a.length; i++) {
+    const current = [i];
+    let rowMin = current[0];
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + cost
+      );
+      rowMin = Math.min(rowMin, current[j]);
+    }
+    if (rowMin > maxDistance) {
+      return maxDistance + 1;
+    }
+    previous = current;
+  }
+
+  return previous[b.length];
+};
+
+const fuzzyTokenScore = (candidateTokens: string[], compactCandidate: string, token: string): number | null => {
+  if (!token) {
+    return 0;
+  }
+
+  let best: number | null = null;
+  for (const candidateToken of candidateTokens) {
+    let score: number | null = null;
+    if (candidateToken === token) {
+      score = 0;
+    } else if (candidateToken.startsWith(token)) {
+      score = 10 + candidateToken.length - token.length;
+    } else if (candidateToken.includes(token)) {
+      score = 25 + candidateToken.indexOf(token);
+    } else if (isSubsequence(token, candidateToken)) {
+      score = 50 + candidateToken.length - token.length;
+    } else if (token.length >= 3) {
+      const maxDistance = Math.max(1, Math.floor(token.length / 3));
+      const distance = levenshteinDistance(token, candidateToken, maxDistance);
+      if (distance <= maxDistance) {
+        score = 80 + distance * 10 + Math.abs(candidateToken.length - token.length);
+      }
+    }
+
+    if (score !== null && (best === null || score < best)) {
+      best = score;
+    }
+  }
+
+  if (best === null && compactCandidate.includes(token)) {
+    return 35 + compactCandidate.indexOf(token);
+  }
+
+  return best;
+};
+
+export const fuzzySearchScore = (text: string, query?: string): number | null => {
+  const trimmedQuery = query?.trim();
+  if (!trimmedQuery) {
+    return 0;
+  }
+
+  const normalizedText = normalizeSearchText(text);
+  const normalizedQuery = normalizeSearchText(trimmedQuery);
+  if (normalizedText === normalizedQuery) {
+    return 0;
+  }
+  if (normalizedText.startsWith(normalizedQuery)) {
+    return 5 + normalizedText.length - normalizedQuery.length;
+  }
+  if (normalizedText.includes(normalizedQuery)) {
+    return 15 + normalizedText.indexOf(normalizedQuery);
+  }
+
+  const candidateTokens = searchTokens(text);
+  const compactCandidate = candidateTokens.join('');
+  const queryTokens = searchTokens(trimmedQuery);
+  let total = 0;
+  for (const token of queryTokens) {
+    const score = fuzzyTokenScore(candidateTokens, compactCandidate, token);
+    if (score === null) {
+      return null;
+    }
+    total += score;
+  }
+
+  return total;
+};
+
+export const fuzzySearchMatch = (text: string, query?: string) => fuzzySearchScore(text, query) !== null;
+
+export function fuzzySearchSort<T>(items: T[], getText: (item: T) => string, query?: string): T[] {
+  return items
+    .map((item, index) => ({ item, index, score: fuzzySearchScore(getText(item), query) }))
+    .filter((item): item is { item: T; index: number; score: number } => item.score !== null)
+    .sort((a, b) => a.score - b.score || a.index - b.index)
+    .map(({ item }) => item);
+}


### PR DESCRIPTION
Generate quoted phrase filters for text values that contain whitespace or punctuation, matching manually-entered Quickwit queries such as service_name:"auth-api" and attributes.grpc_message:"...".

Keep unquoted term filters only for simple token values and escape term values correctly.

Improve filter autocomplete with fuzzy matching for keys and values, and pass previous complete filters into later value lookups so suggestions narrow progressively.

Add tests for phrase rendering, punctuated values, term escaping, fuzzy matching, and prior-filter selection.