### PR TITLE
fix: declare accurate grafanaDependency for jsx-runtime externalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ or you can download the latest version and follow the
 
 ## Version compatibility
 
-We recommend Grafana v12.1+ or v13.
+We recommend Grafana v12.3+ or v13.
+
+v0.6.x requires a Grafana version that provides `react/jsx-runtime` to plugins: 12.3+ and 13, or the patch releases 12.0.10+, 12.1.7+ and 12.2.5+ on older minors. Earlier 12.x patch versions (e.g. 12.0.0) cannot load the plugin.
 
 Quickwit 0.7 is compatible with 0.3.x versions only.
 
 Quickwit 0.8 is compatible with 0.4.x, 0.5.x and 0.6.x versions.
 
-- **v0.6.x** (Latest): Grafana 12.1+ and 13 (React 19)
+- **v0.6.x** (Latest): Grafana 12.0.10+ / 12.1.7+ / 12.2.5+ / 12.3+ and 13 (React 19)
 - **v0.5.x**: Grafana 11.x
 - **v0.4.x**: Grafana 10.x
 - **v0.3.x**: Grafana 9.x / Quickwit 0.7

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -58,7 +58,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=12",
+    "grafanaDependency": ">=12.0.10 <12.1 || >=12.1.7 <12.2 || >=12.2.5",
     "plugins": []
   }
 }


### PR DESCRIPTION
The plugin externalizes `react/jsx-runtime` (required for React 19 / Grafana 13 support), so it only loads on Grafana versions that provide that module to plugins: 12.3+ and the backport patches 12.0.10, 12.1.7 and 12.2.5. The previous `>=12` declaration wrongly included versions like 12.0.0, where the config editor fails to render.

Flagged by the Grafana plugin review of v0.6.2.

The new range is the canonical output of `npx @grafana/create-plugin@latest add externalize-jsx-runtime` (create-plugin 7.9.0); the webpack externals part of that fixlet was already in place. Verified with plugincheck2 (no new findings) and node-semver resolution against 12.0.0–13.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)